### PR TITLE
Email integration

### DIFF
--- a/node-datasource/controllers/ImapController.js
+++ b/node-datasource/controllers/ImapController.js
@@ -1,0 +1,80 @@
+(function () {
+  "use strict";
+
+  // https://shackbarth-470-dev.localhost/demo_dev/imap/search?address=ned@xtuple.com
+  exports.search = function (req, res) {
+    console.log(req.query.address);
+    var Imap = require('imap'),
+      inspect = require('util').inspect,
+      returnResults = [];
+
+    var imap = new Imap(X.options.datasource.imapUser);
+
+    function openInbox(cb) {
+      imap.openBox('INBOX', true, cb);
+    }
+
+    imap.once('ready', function () {
+      openInbox(function (err, box) {
+        if (err) throw err;
+        imap.search([ 'ALL', ['FROM', req.query.address] ], function (err, results) {
+          if (err) throw err;
+          var f = imap.fetch(results, { bodies: ['HEADER.FIELDS (FROM TO)','TEXT'] });
+          f.on('message', function (msg, seqno) {
+            //console.log('Message #%d', seqno);
+            var prefix = '(#' + seqno + ') ';
+            var returnResult = {};
+            msg.on('body', function (stream, info) {
+              if (info.which === 'TEXT')
+                //console.log(prefix + 'Body [%s] found, %d total bytes', inspect(info.which), info.size);
+              var buffer = '', count = 0;
+              stream.on('data', function (chunk) {
+                count += chunk.length;
+                buffer += chunk.toString('utf8');
+                if (info.which === 'TEXT') {
+                  //console.log(prefix + 'Body [%s] (%d/%d)', inspect(info.which), count, info.size);
+                }
+              });
+              stream.once('end', function () {
+                if (info.which !== 'TEXT') {
+                  //console.log(prefix + 'Parsed header: %s', inspect(Imap.parseHeader(buffer)));
+                  _.extend(returnResult, Imap.parseHeader(buffer));
+                } else {
+                  returnResult.body = inspect(buffer); // TODO: mime parsing
+                  //console.log(prefix + 'Body [%s] Finished', inspect(buffer));
+                }
+              });
+            });
+            msg.once('attributes', function (attrs) {
+              _.extend(returnResult, attrs);
+              //console.log(prefix + 'Attributes: %s', inspect(attrs, false, 8));
+            });
+            msg.once('end', function () {
+              //console.log(prefix + 'Finished');
+              returnResults.push(returnResult);
+            });
+          });
+          f.once('error', function (err) {
+            console.log('Fetch error: ' + err);
+          });
+          f.once('end', function () {
+            console.log('Done fetching all messages!');
+            imap.end();
+            res.send(returnResults);
+          });
+        });
+      });
+    });
+
+    imap.once('error', function (err) {
+      console.log(err);
+    });
+
+    imap.once('end', function () {
+      console.log('Connection ended');
+    });
+
+    imap.connect();
+
+  };
+}());

--- a/node-datasource/controllers/ImapController.js
+++ b/node-datasource/controllers/ImapController.js
@@ -12,18 +12,8 @@
   var reportedFields = ["html", "text", "subject", "from", "to", "date"],
     returnResults = [];
 
-  // https://shackbarth-470-dev.localhost/demo_dev/imap/search?address=to_or_from@mycompany.com
-
-  /*
-    Necessary setup: configure your mail server so that it automatically bcc's an "archive"
-    email address. Put the creds for that address in the config file.
-
-    Not sure if this is possible with gmail, I think it's unlikely:
-    http://thenextweb.com/google/2012/07/03/if-youre-a-google-apps-admin-you-will-now-have-access-to-a-gmail-log-search
-
-    Gmail has lots of nice integration options, and this route could easily be expanded to
-    use the gmail API without changing its own API to the xTuple clients.
-  */
+  // the helper function that does all the work of searching imap.
+  // can be called by the route or through the CLI.
   var searchImap = function (creds, box, query, callback) {
     var imap = new Imap(creds);
     imap.once('ready', function () {
@@ -88,10 +78,17 @@
     });
   };
 
+  // https://localhost/demo_dev/imap/search?address=you@yourcompany.com
   exports.search = function (req, res) {
     var query = [ 'ALL', ['OR', ['FROM', req.query.address], ['TO', req.query.address] ] ];
     // TODO: secure this route with a privilege
-    // TODO: we should really store these creds in the database and have a UI to manage them
+    // TODO: allow other kinds of queries other than to/from address?
+    // https://github.com/mscdex/node-imap#examples
+    // TODO for v2.0: we should really store these creds in the database and have a UI to manage them
+
+    // TODO: if (X.options.datasource.imap.useCache) { search the database instead of the imap server }
+    //    see scripts/cache_email.js
+
     searchAllImap(X.options.datasource.imap, query, function (err, results) {
       if (err) {
         console.log("Error searching imap", err);

--- a/node-datasource/controllers/ImapController.js
+++ b/node-datasource/controllers/ImapController.js
@@ -1,16 +1,19 @@
 (function () {
   "use strict";
 
+  var _ = require("underscore"),
+    Imap = require('imap'),
+    inspect = require('util').inspect,
+    MailParser = require("mailparser").MailParser,
+    mailparser = new MailParser(),
+    imap = new Imap(X.options.datasource.imapUser);
+
+  // choosing to ignore attachments, headers, references, inReplyTo, priority, messageId
+  var reportedFields = ["html", "text", "subject", "from", "to", "date"],
+    returnResults = [];
+
   // https://shackbarth-470-dev.localhost/demo_dev/imap/search?address=ned@xtuple.com
   exports.search = function (req, res) {
-    console.log(req.query.address);
-    var Imap = require('imap'),
-      inspect = require('util').inspect,
-      returnResults = [];
-    var MailParser = require("mailparser").MailParser,
-      mailparser = new MailParser();
-
-    var imap = new Imap(X.options.datasource.imapUser);
 
     function openInbox(cb) {
       imap.openBox('INBOX', true, cb);
@@ -19,12 +22,14 @@
     imap.once('ready', function () {
       openInbox(function (err, box) {
         if (err) throw err;
-        imap.search([ 'ALL', ['FROM', req.query.address] ], function (err, results) {
-          if (err) throw err;
-          console.log("res count", results.length);
+        imap.search([ 'ALL', ['OR', ['FROM', req.query.address], ['TO', req.query.address] ] ], function (err, results) {
+          if (err) {
+            res.send(500);
+            return;
+          }
+
           mailparser.on("end", function (mail_object){
-            returnResults.push(mail_object);
-            console.log("mailparser end");
+            returnResults.push(_.pick(mail_object, reportedFields));
             if (returnResults.length === results.length) {
               res.send(returnResults);
             }
@@ -33,46 +38,20 @@
           var f = imap.fetch(results, { bodies: [''] });
 
           f.on('message', function (msg, seqno) {
-            //console.log('Message #%d', seqno);
-            var prefix = '(#' + seqno + ') ';
-            var returnResult = {};
             msg.on('body', function (stream, info) {
-              if (info.which === 'TEXT')
-                //console.log(prefix + 'Body [%s] found, %d total bytes', inspect(info.which), info.size);
-              var buffer = '', count = 0;
               stream.on('data', function (chunk) {
-                //count += chunk.length;
                 mailparser.write(chunk.toString('utf8'));
-                //if (info.which === 'TEXT') {
-                  //console.log(prefix + 'Body [%s] (%d/%d)', inspect(info.which), count, info.size);
-                //}
               });
-              stream.once('end', function () {
-                console.log("stream end");
-                //if (info.which !== 'TEXT') {
-                  //console.log(prefix + 'Parsed header: %s', inspect(Imap.parseHeader(buffer)));
-                  //_.extend(returnResult, Imap.parseHeader(buffer));
-                //} else {
-                  //returnResult.body = inspect(buffer); // TODO: mime parsing
-                  //console.log(prefix + 'Body [%s] Finished', inspect(buffer));
-                //}
-              });
-            });
-            msg.once('attributes', function (attrs) {
-              _.extend(returnResult, attrs);
-              //console.log(prefix + 'Attributes: %s', inspect(attrs, false, 8));
             });
             msg.once('end', function () {
-              console.log("message end");
-              //console.log(prefix + 'Finished');
               mailparser.end();
             });
           });
           f.once('error', function (err) {
             console.log('Fetch error: ' + err);
+            res.send(500);
           });
           f.once('end', function () {
-            console.log('Done fetching all messages!');
             imap.end();
           });
         });
@@ -80,14 +59,9 @@
     });
 
     imap.once('error', function (err) {
-      console.log(err);
-    });
-
-    imap.once('end', function () {
-      console.log('Connection ended');
+      res.send(500);
     });
 
     imap.connect();
-
   };
 }());

--- a/node-datasource/controllers/ImapController.js
+++ b/node-datasource/controllers/ImapController.js
@@ -5,22 +5,30 @@
     Imap = require('imap'),
     inspect = require('util').inspect,
     MailParser = require("mailparser").MailParser,
-    mailparser = new MailParser(),
-    imap = new Imap(X.options.datasource.imapUser);
+    mailparser = new MailParser();
 
   // choosing to ignore attachments, headers, references, inReplyTo, priority, messageId
   var reportedFields = ["html", "text", "subject", "from", "to", "date"],
     returnResults = [];
 
-  // https://shackbarth-470-dev.localhost/demo_dev/imap/search?address=ned@xtuple.com
+  // https://shackbarth-470-dev.localhost/demo_dev/imap/search?address=to_or_from@mycompany.com
+
+  /*
+    Necessary setup: configure your mail server so that it automatically bcc's an "archive"
+    email address. Put the creds for that address in the config file.
+
+    Not sure if this is possible with gmail, I think it's unlikely:
+    http://thenextweb.com/google/2012/07/03/if-youre-a-google-apps-admin-you-will-now-have-access-to-a-gmail-log-search
+
+    Gmail has lots of nice integration options, and this route could easily be expanded to
+    use the gmail API without changing its own API to the xTuple clients.
+  */
   exports.search = function (req, res) {
 
-    function openInbox(cb) {
-      imap.openBox('INBOX', true, cb);
-    }
-
+    var imap = new Imap(X.options.datasource.imapUser);
+    // TODO: secure this route with a privilege
     imap.once('ready', function () {
-      openInbox(function (err, box) {
+      imap.openBox('INBOX', true, function (err, box) {
         if (err) throw err;
         imap.search([ 'ALL', ['OR', ['FROM', req.query.address], ['TO', req.query.address] ] ], function (err, results) {
           if (err) {

--- a/node-datasource/main.js
+++ b/node-datasource/main.js
@@ -499,6 +499,27 @@ app.get('/:org/reset-password', routes.resetPassword);
 app.post('/:org/oauth/revoke-token', routes.revokeOauthToken);
 app.all('/:org/vcfExport', routes.vcfExport);
 
+
+// sailsjs-style CoC route definitions from node-datasource/controllers
+// TODO: put these into the discovery doc
+// TODO: if this works, migrate all the above routes to this convention
+X.fs.readdir(X.path.resolve(__dirname, "controllers"), function (err, filenames) {
+  "use strict";
+  var controllerFilenames = _.filter(filenames, function (filename) {
+    return filename.indexOf("Controller.js") === filename.length - "Controller.js".length;
+  });
+
+  _.each(controllerFilenames, function (filename) {
+    var routes = require(X.path.resolve(__dirname, "controllers", filename));
+    // TODO: armadillo-case multi-word filenames
+    var urlBase = filename.substring(0, filename.indexOf("Controller.js")).toLowerCase();
+    _.each(routes, function (route, functionName) {
+      app.all("/:org/" + urlBase + "/" + functionName, route);
+    });
+  });
+});
+
+
 // Set up the other servers we run on different ports.
 
 var redirectServer = express();

--- a/node-datasource/main.js
+++ b/node-datasource/main.js
@@ -514,7 +514,10 @@ X.fs.readdir(X.path.resolve(__dirname, "controllers"), function (err, filenames)
     // TODO: armadillo-case multi-word filenames
     var urlBase = filename.substring(0, filename.indexOf("Controller.js")).toLowerCase();
     _.each(routes, function (route, functionName) {
-      app.all("/:org/" + urlBase + "/" + functionName, route);
+      app.all("/:org/" + urlBase + "/" + functionName, [
+        require('connect-ensure-login').ensureLoggedIn({redirectTo: "/logout"}),
+        route
+      ]);
     });
   });
 });

--- a/node-datasource/sample_config.js
+++ b/node-datasource/sample_config.js
@@ -43,6 +43,14 @@ newcap:true, noarg:true, regexp:true, undef:true, strict:true, trailing:true, wh
       smtpPort: 587,
       smtpUser: "",
       smtpPassword: "",
+      imap: {
+        users: [
+          { user: "bob", password: "mypass", box: "INBOX.ERP" }
+        ],
+        host: "mail.mycompany.com",
+        port: 993,
+        tls: true
+      },
       printer: "",
 
       // these properties are dynamically registered with the

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "imap": "^0.8.14",
     "json-patch": "git://github.com/xtuple/JSON-Patch.git",
     "less": "1.5.0",
+    "mailparser": "^0.4.6",
     "moment": "2.4.x",
     "node-forge": "0.6.x",
     "nodemailer": "0.3.x",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "ejs": "0.8.x",
     "express": "3.1.x",
     "fluentreports": "git://github.com/xtuple/fluentreports.git",
+    "imap": "^0.8.14",
     "json-patch": "git://github.com/xtuple/JSON-Patch.git",
     "less": "1.5.0",
     "moment": "2.4.x",

--- a/scripts/cache_email.js
+++ b/scripts/cache_email.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+/*jshint node:true, indent:2, curly:false, eqeqeq:true, immed:true, latedef:true, newcap:true, noarg:true,
+regexp:true, undef:true, strict:true, trailing:true, white:true */
+/*global _:true */
+
+//
+// This file really just parses the arguments, and sends the real work
+// off to scripts/lib/build_all.js.
+//
+
+(function () {
+  "use strict";
+
+  var fs = require("fs"),
+    program = require("commander"),
+    path = require("path"),
+    imapController = require("../node-datasource/controllers/ImapController"),
+    dataSource = require('../node-datasource/lib/ext/datasource').dataSource,
+    configPath,
+    config;
+
+  program
+    .option('-c, --config [/path/to/alternate_config.js]', 'Location of datasource config file. [config.js]')
+    .parse(process.argv);
+  configPath = program.config ?
+    path.resolve(process.cwd(), program.config) :
+    path.resolve(__dirname, "../node-datasource/config.js");
+  config = require(configPath);
+
+  var query = [ 'ALL' ];
+  // TODO: we should really store these creds in the database and have a UI to manage them
+  imapController.searchAllImap(config.datasource.imap, query, function (err, results) {
+    if (err) {
+      console.log("Imap Cache Failed", err);
+      return;
+    }
+    var options = JSON.parse(JSON.stringify(config.databaseServer));
+    var sql = "SELECT setMetric('Test234', $1);";
+    options.database = config.databases[0];
+    options.parameters = [JSON.stringify(results)];
+    dataSource.query(sql, options, function (err, insertResults) {
+      console.log("Imap cache succeeded with " + results.length + " records");
+      console.log("done", arguments);
+    });
+  });
+
+}());

--- a/scripts/cache_email.js
+++ b/scripts/cache_email.js
@@ -23,6 +23,7 @@ regexp:true, undef:true, strict:true, trailing:true, white:true */
   program
     .option('-c, --config [/path/to/alternate_config.js]', 'Location of datasource config file. [config.js]')
     .parse(process.argv);
+
   configPath = program.config ?
     path.resolve(process.cwd(), program.config) :
     path.resolve(__dirname, "../node-datasource/config.js");
@@ -37,6 +38,10 @@ regexp:true, undef:true, strict:true, trailing:true, white:true */
     }
     var options = JSON.parse(JSON.stringify(config.databaseServer));
     var sql = "SELECT setMetric('Test234', $1);";
+
+    // TODO: persist to email table
+    // TODO: if the message line matches some document, add to docass
+
     options.database = config.databases[0];
     options.parameters = [JSON.stringify(results)];
     dataSource.query(sql, options, function (err, insertResults) {

--- a/scripts/cache_email.js
+++ b/scripts/cache_email.js
@@ -5,8 +5,8 @@ regexp:true, undef:true, strict:true, trailing:true, white:true */
 /*global _:true */
 
 //
-// This file really just parses the arguments, and sends the real work
-// off to scripts/lib/build_all.js.
+// In order to cache emails in the database, customers are going to want to set this
+// to run on a cron.
 //
 
 (function () {
@@ -37,16 +37,34 @@ regexp:true, undef:true, strict:true, trailing:true, white:true */
       return;
     }
     var options = JSON.parse(JSON.stringify(config.databaseServer));
-    var sql = "SELECT setMetric('Test234', $1);";
+    var sql = "SELECT setMetric('Test234', $1);"; // XXX obviously it won't be setMetric here
 
     // TODO: persist to email table
-    // TODO: if the message line matches some document, add to docass
+    // no need to use the existing eml tables
+    // probably one table will suffice
 
-    options.database = config.databases[0];
-    options.parameters = [JSON.stringify(results)];
+    // columns could be:
+    // id
+    // subject
+    // date
+    // from
+    // to
+    // cc ? bcc ?
+    // subject
+    // body as text
+    // body as html
+    // attachments (maybe v2.0)
+    // hash (hash the body as a way to check to see if this email is already in the table)
+    // other fields from the header? (imap message id)
+
+    // TODO: if the subject line matches some document, add to docass
+    //   use the existing conventions for what the email subject should look like to denote
+    //   a document link
+
+    options.database = config.databases[0]; // XXX bit of an assumption here
+    options.parameters = [JSON.stringify(results)]; // XXX obviously no
     dataSource.query(sql, options, function (err, insertResults) {
       console.log("Imap cache succeeded with " + results.length + " records");
-      console.log("done", arguments);
     });
   });
 


### PR DESCRIPTION
Not ready for pull yet, and destined for 4.9, but worthwhile opening for discussion.

This code exposes a REST endpoint to show all messages to/from a particular email address. The way the Qt client would consume this endpoint would be that there'd be an email tab in the contact workspace (something similar could be set up for accounts, too) that would make a HTTP request to this endpoint, and would render the resultant JSON however it sees fit.

Configuration options: 

1. The simplest way to set this up is to go into your mail server, add an archive-y email address, bcc all communication to that address, and then enter into our system the creds for that address. The imap search can be done in real time on that address without the need to put anything in a table in our database.

2. Option 1 probably won't work for gmail. It's also possible to put in an array of imap creds, for each user, and the search will look across all configured imap accounts. In this configuration option (and the third, it's furthermore possible to specify a given folder ("INBOX.ERP") as the place the search will look. This is a good option for users that are nervous about having *every single* one of their emails in the ERP.

3. It's furthermore possible to run these searches on a schedule and cache the results into the database. This would be an improvement over option 2 because it would work even if users delete their emails or if their account is removed. The downside is that you're likely to end up with a bloated database.