### PR TITLE
fix test failures that started around the new year

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "start": "node_modules/.bin/nodemon node-datasource/main.js --debug --watch node-datasource",
     "test-build": "./node_modules/.bin/mocha -R spec test/build/build_app.js",
     "test": "./node_modules/.bin/mocha -R spec test/lib/login.js test/models/* test/database/* test/extensions/* test/lib/test_runner.js",
-    "test-datasource": "./node_modules/.bin/mocha -R spec test/routes/*"
+    "test-datasource": "./node_modules/.bin/mocha -R spec test/routes/*",
+    "test-database": "./node_modules/.bin/mocha -R spec test/database/*"
   }
 }


### PR DESCRIPTION
The fre test was failing because the dev database created by build_app doesn't have accounting periods in 2015. This fixes that by creating accounting periods in the current year.
The change to `package.json` allows running the database tests in isolation, which will become more useful in the next month or so as the number of stored procedure and trigger tests grows.