### PR TITLE
Expose user preferences to REST

### DIFF
--- a/database/source/xm/javascript/user_preference.sql
+++ b/database/source/xm/javascript/user_preference.sql
@@ -14,13 +14,13 @@ select xt.install_js('XM','UserPreference','xtuple', $$
   };
   XM.UserPreference.getPreference.description = "Return the user preferences for the logged-in user";
   XM.UserPreference.getPreference.request = {
-    "$ref": "UserPreference"
+    "$ref": "GetPreference"
   };
   XM.UserPreference.getPreference.parameterOrder = [
     "name"
   ];
   XM.UserPreference.getPreference.schema = {
-    UserPreference: {
+    GetPreference: {
       properties: {
         attributes: {
           title: "Service request attributes",
@@ -52,14 +52,14 @@ select xt.install_js('XM','UserPreference','xtuple', $$
   };
   XM.UserPreference.commitPreference.description = "Persist a user preferences for the logged-in user";
   XM.UserPreference.commitPreference.request = {
-    "$ref": "UserPreference"
+    "$ref": "CommitPreference"
   };
   XM.UserPreference.commitPreference.parameterOrder = [
     "name",
     "value"
   ];
   XM.UserPreference.commitPreference.schema = {
-    UserPreference: {
+    CommitPreference: {
       properties: {
         attributes: {
           title: "Service request attributes",

--- a/database/source/xm/javascript/user_preference.sql
+++ b/database/source/xm/javascript/user_preference.sql
@@ -10,7 +10,7 @@ select xt.install_js('XM','UserPreference','xtuple', $$
   XM.UserPreference.getPreference = function (name) {
     var sql = "select userpref_value from xt.userpref where userpref_usr_username = $1 and userpref_name = $2";
     var result = plv8.execute(sql, [XT.username, name]);
-    return {status: 200, result: result, name: name};
+    return {result: result};
   };
   XM.UserPreference.getPreference.description = "Return the user preferences for the logged-in user";
   XM.UserPreference.getPreference.request = {
@@ -28,7 +28,7 @@ select xt.install_js('XM','UserPreference','xtuple', $$
       "select $1, $2, $3 " +
       "where not exists (select 1 from xt.userpref where userpref_usr_username = $1 and userpref_name = $2)";
     var result = plv8.execute(sql, [XT.username, name, value]);
-    return {status: 200, result: result, name: name};
+    return {result: result};
   };
   XM.UserPreference.commitPreference.description = "Persist a user preferences for the logged-in user";
   XM.UserPreference.commitPreference.request = {

--- a/database/source/xm/javascript/user_preference.sql
+++ b/database/source/xm/javascript/user_preference.sql
@@ -20,6 +20,26 @@ select xt.install_js('XM','UserPreference','xtuple', $$
     "name"
   ];
   XM.UserPreference.getPreference.schema = {
+    UserPreference: {
+      properties: {
+        attributes: {
+          title: "Service request attributes",
+          description: "An array of attributes needed to get a users preferences.",
+          type: "array",
+          items: [
+            {
+              title: "Name",
+              description: "Preference Name",
+              type: "text",
+              required: true
+            }
+          ],
+          "minItems": 1,
+          "maxItems": 1,
+          required: true
+        }
+      }
+    }
   };
 
   XM.UserPreference.commitPreference = function (name, value) {
@@ -39,6 +59,32 @@ select xt.install_js('XM','UserPreference','xtuple', $$
     "value"
   ];
   XM.UserPreference.commitPreference.schema = {
+    UserPreference: {
+      properties: {
+        attributes: {
+          title: "Service request attributes",
+          description: "An array of attributes needed to set a users preferences.",
+          type: "array",
+          items: [
+            {
+              title: "Name",
+              description: "Preference Name",
+              type: "text",
+              required: true
+            },
+            {
+              title: "Value",
+              description: "Preference Value",
+              type: "text",
+              required: true
+            }
+          ],
+          "minItems": 2,
+          "maxItems": 2,
+          required: true
+        }
+      }
+    }
   };
 
 $$ );

--- a/database/source/xm/javascript/user_preference.sql
+++ b/database/source/xm/javascript/user_preference.sql
@@ -5,6 +5,40 @@ select xt.install_js('XM','UserPreference','xtuple', $$
   XM.UserPreference = {
     options: ["PrintSettings"]
   };
+  XM.UserPreference.isDispatchable = true;
+
+  XM.UserPreference.getPreference = function (name) {
+    var sql = "select userpref_value from xt.userpref where userpref_usr_username = $1 and userpref_name = $2";
+    var result = plv8.execute(sql, [XT.username, name]);
+    return {status: 200, result: result, name: name};
+  };
+  XM.UserPreference.getPreference.description = "Return the user preferences for the logged-in user";
+  XM.UserPreference.getPreference.request = {
+    "$ref": "UserPreference"
+  };
+  XM.UserPreference.getPreference.parameterOrder = [
+    "name"
+  ];
+  XM.UserPreference.getPreference.schema = {
+  };
+
+  XM.UserPreference.commitPreference = function (name, value) {
+    var sql = "update xt.userpref set userpref_value = $3 where userpref_usr_username = $1 and userpref_name = $2; " +
+      "insert into xt.userpref (userpref_usr_username, userpref_name, userpref_value) VALUES ($1, $2, $3) " +
+      "where not exists (select 1 from xt.userpref where userpref_usr_username = $1 and userpref_name = $2)";
+    var result = plv8.execute(sql, [XT.username, name, value]);
+    return {status: 200, result: result, name: name};
+  };
+  XM.UserPreference.commitPreference.description = "Persist a user preferences for the logged-in user";
+  XM.UserPreference.commitPreference.request = {
+    "$ref": "UserPreference"
+  };
+  XM.UserPreference.commitPreference.parameterOrder = [
+    "name",
+    "value"
+  ];
+  XM.UserPreference.commitPreference.schema = {
+  };
 
 $$ );
 

--- a/database/source/xm/javascript/user_preference.sql
+++ b/database/source/xm/javascript/user_preference.sql
@@ -24,7 +24,8 @@ select xt.install_js('XM','UserPreference','xtuple', $$
 
   XM.UserPreference.commitPreference = function (name, value) {
     var sql = "update xt.userpref set userpref_value = $3 where userpref_usr_username = $1 and userpref_name = $2; " +
-      "insert into xt.userpref (userpref_usr_username, userpref_name, userpref_value) VALUES ($1, $2, $3) " +
+      "insert into xt.userpref (userpref_usr_username, userpref_name, userpref_value) " +
+      "select $1, $2, $3 " +
       "where not exists (select 1 from xt.userpref where userpref_usr_username = $1 and userpref_name = $2)";
     var result = plv8.execute(sql, [XT.username, name, value]);
     return {status: 200, result: result, name: name};


### PR DESCRIPTION
Easy way to persist and retrieve user preferences via REST. The user is assumed to be whatever user is making the request. Note that we persist to `xt.userpref` and not `public.usrpref`. 

```
$.ajax({
      url: '/' + org + '/browser-api/v1/services/user-preference/commit-preference',
      type: "POST",
      dataType: "json",
      data: {
        attributes: [
          "my_userpref_name",
          "my_userpref_value"
        ]
      }
});
```

```
$.ajax({
      url: '/' + org + '/browser-api/v1/services/user-preference/get-preference',
      type: "POST",
      dataType: "json",
      data: {
        attributes: [
          "my_userpref_value"
        ]
      }
});
```