### PR TITLE
add dashboard-anything to default extension list

### DIFF
--- a/scripts/lib/util/default_extensions.js
+++ b/scripts/lib/util/default_extensions.js
@@ -16,6 +16,7 @@ regexp:true, undef:true, strict:true, trailing:true, white:true */
     path.join(__dirname, '../../../enyo-client/extensions/source/sales'),
     path.join(__dirname, '../../../enyo-client/extensions/source/billing'),
     path.join(__dirname, '../../../enyo-client/extensions/source/purchasing'),
-    path.join(__dirname, '../../../enyo-client/extensions/source/oauth2')
+    path.join(__dirname, '../../../enyo-client/extensions/source/oauth2'),
+    path.join(__dirname, '../../../node_modules/xtuple-dashboard-anything')
   ];
 }());


### PR DESCRIPTION
No need to pull this until dashboard-anything is more ready, but this is all that's necessary to put dashboard-anything into new installations.

To get it onto existing installs, execute this command (even though that directory won't exist yet):

```
$ ./scripts/build_app.js -d demo_dev -e node_modules/xtuple-dashboard-anything
```