### PR TITLE
lexicographic order ain't numeric order

### DIFF
--- a/scripts/xml/postbooks_package.xml
+++ b/scripts/xml/postbooks_package.xml
@@ -19,7 +19,15 @@
 
   <prerequisite type = "query"
                 name = "Checking for too-new xTuple ERP database version" >
-    <query>SELECT NOT fetchMetricText('ServerVersion') >= '4.10.0';</query>
+    <query>WITH parts AS (
+             SELECT regexp_split_to_array(fetchMetricText('ServerVersion'), E'\\.') AS num,
+                    regexp_replace(fetchMetricText('ServerVersion'),
+                                   E'^[0-9]+\\.[0-9]+\\.[0-9]+', '') AS qual
+           )
+           SELECT NOT num[1]::INTEGER > 4
+              AND NOT num[2]::INTEGER > 9
+              AND NOT num[3]::INTEGER > 0
+             FROM parts;</query>
     <message>This package may not be applied to a database newer than 4.9.0.
     </message>
   </prerequisite>


### PR DESCRIPTION
testing upgrade to 4.9.0Beta was failing the prereq check because the string `4.10.0` is less than `4.9.0`