### PR TITLE
issue #24213 - expand compare versions function

### DIFF
--- a/foundation-database/manifest.js
+++ b/foundation-database/manifest.js
@@ -52,6 +52,7 @@
     "public/types/wodata.sql",
     "public/types/woinvav.sql",
 
+    "public/functions/_normalizeversion.sql",
     "public/functions/acknowledgemessage.sql",
     "public/functions/actcost.sql",
     "public/functions/addrusecount.sql",

--- a/foundation-database/manifest.js
+++ b/foundation-database/manifest.js
@@ -154,6 +154,7 @@
     "public/functions/cntctselectcol.sql",
     "public/functions/cntctused.sql",
     "public/functions/coheadstatecolor.sql",
+    "public/functions/compareversion.sql",
     "public/functions/concatagg.sql",
     "public/functions/consolidatelocations.sql",
     "public/functions/convertcustomertoprospect.sql",

--- a/foundation-database/public/functions/_normalizeversion.sql
+++ b/foundation-database/public/functions/_normalizeversion.sql
@@ -34,8 +34,14 @@ BEGIN
                     WHEN 'alpha' THEN 20
                     ELSE 10
                END,
-               COALESCE(_part[9], '0')::SMALLINT,       -- beta < beta2
-               ascii(lower(COALESCE(_part[10], '_')))   -- 2 < 2a
+               CASE WHEN _part[9] IS NULL THEN 0
+                    WHEN _part[9] = ''    THEN 0
+                    ELSE _part[9]::SMALLINT             -- beta < beta2
+               END,
+               ascii(CASE WHEN _part[10] IS NULL THEN '_'
+                          WHEN _part[10] = ''    THEN '_'
+                          ELSE lower(COALESCE(_part[10], '_'))
+                     END)   -- 2 < 2a
              ];
   IF _debug THEN RAISE NOTICE '_part: % -> _result: %', _part, _result; END IF;
   IF _part[1] IS NULL OR _part[2] IS NULL THEN

--- a/foundation-database/public/functions/_normalizeversion.sql
+++ b/foundation-database/public/functions/_normalizeversion.sql
@@ -1,0 +1,45 @@
+CREATE OR REPLACE FUNCTION public._normalizeVersion(pVersion TEXT) RETURNS SMALLINT[] AS
+$$
+-- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple. 
+-- See www.xtuple.com/CPAL for the full text of the software license.
+-- Convert an arbitrary version number string to an array of integers.
+-- Supports the following styles:
+--   xTuple   4.5.6Beta2A
+--   semver   4.5.6-beta.2.a+buildId
+--   postgres 9.3
+DECLARE
+  _result SMALLINT[];  -- 4.5.6
+  _part   TEXT[];
+  _debug  BOOLEAN := false;
+BEGIN
+  -- extract 4.5.6
+  _part := regexp_matches(pVersion,                  -- v------- 6 ------v
+             -- capture                v-3-v                     v-- 8 --v
+             --   1          2         4   5            7        9       10
+             --   4       .  5         .   6       -    beta     2        a
+             E'^([0-9]+)\\.([0-9]+)((\\.)([0-9]+))?-?(([a-z]+)(([0-9]*)([a-z]?)?)?)?', 'i');
+  IF _debug THEN
+    RAISE NOTICE 'M: % N: % dP: % d: % P: % rest: % alpha: % sub: % num: % let: %',
+                _part[1], _part[2], _part[3], _part[4], _part[5],
+                _part[6], _part[7], _part[8], _part[9], _part[10];
+  END IF;
+  _result := ARRAY [
+               _part[1]::SMALLINT,
+               _part[2]::SMALLINT,
+               COALESCE(_part[5]::SMALLINT, 0),
+               CASE lower(COALESCE(_part[7], '')) 
+                    WHEN ''      THEN 50
+                    WHEN 'rc'    THEN 40
+                    WHEN 'beta'  THEN 30
+                    WHEN 'alpha' THEN 20
+                    ELSE 10
+               END,
+               COALESCE(_part[9], '99')::SMALLINT,
+               ascii(lower(COALESCE(_part[10], 'z')))
+             ];
+  IF _part[1] IS NULL OR _part[2] IS NULL THEN
+    RAISE EXCEPTION '% is not recognized as a valid version number', pVersion;
+  END IF;
+  RETURN _result;
+END;
+$$ LANGUAGE plpgsql STABLE;

--- a/foundation-database/public/functions/_normalizeversion.sql
+++ b/foundation-database/public/functions/_normalizeversion.sql
@@ -13,11 +13,11 @@ DECLARE
   _debug  BOOLEAN := false;
 BEGIN
   -- extract 4.5.6
-  _part := regexp_matches(pVersion,                  -- v------- 6 ------v
-             -- capture                v-3-v                     v-- 8 --v
-             --   1          2         4   5            7        9       10
-             --   4       .  5         .   6       -    beta     2        a
-             E'^([0-9]+)\\.([0-9]+)((\\.)([0-9]+))?-?(([a-z]+)(([0-9]*)([a-z]?)?)?)?', 'i');
+  _part := regexp_matches(pVersion, --                  v----------- 6 -----------v
+             -- capture                v-3-v                         v---- 8 ----v
+             --   1          2         4   5            7            9          10
+             --   4       .  5         .   6       -    beta         2           a
+             E'^([0-9]+)\\.([0-9]+)((\\.)([0-9]+))?-?(([a-z]+)\\.?(([0-9]*)\\.?([a-z]?)?)?)?', 'i');
   IF _debug THEN
     RAISE NOTICE 'M: % N: % dP: % d: % P: % rest: % alpha: % sub: % num: % let: %',
                 _part[1], _part[2], _part[3], _part[4], _part[5],
@@ -34,9 +34,10 @@ BEGIN
                     WHEN 'alpha' THEN 20
                     ELSE 10
                END,
-               COALESCE(_part[9], '99')::SMALLINT,
-               ascii(lower(COALESCE(_part[10], 'z')))
+               COALESCE(_part[9], '0')::SMALLINT,       -- beta < beta2
+               ascii(lower(COALESCE(_part[10], '_')))   -- 2 < 2a
              ];
+  IF _debug THEN RAISE NOTICE '_part: % -> _result: %', _part, _result; END IF;
   IF _part[1] IS NULL OR _part[2] IS NULL THEN
     RAISE EXCEPTION '% is not recognized as a valid version number', pVersion;
   END IF;

--- a/foundation-database/public/functions/compareversion.sql
+++ b/foundation-database/public/functions/compareversion.sql
@@ -1,67 +1,40 @@
-CREATE OR REPLACE FUNCTION public.compareversion(text, text DEFAULT split_part(version(), ' '::text, 2))
+CREATE OR REPLACE FUNCTION public.compareversion(pLeft text, pRight text DEFAULT split_part(version(), ' '::text, 2))
+  RETURNS integer AS
+$$
 -- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple. 
 -- See www.xtuple.com/CPAL for the full text of the software license.
 -- Returns 1 if the left version is greater than the right version
 -- -1 if the right is greater than the left
 --  0 if the versions are equal.
 -- parameter two defaults to current server version
-  RETURNS integer AS
-$BODY$
 DECLARE
-  _leftVersion ALIAS FOR $1;
-  _rightVersion ALIAS FOR $2;
-  _leftMajor SMALLINT;
-  _leftMinor SMALLINT;
-  _leftPatch SMALLINT;
-  _rightMajor SMALLINT;
-  _rightMinor SMALLINT;
-  _rightPatch SMALLINT;
-  _returnCode SMALLINT;
-  DEBUG BOOLEAN := false;
+  _left   SMALLINT[] := _normalizeVersion(pLeft);
+  _right  SMALLINT[] := _normalizeVersion(pRight);
+  _result SMALLINT   := 0;
+  _major  SMALLINT   := 1;  -- 4
+  _minor  SMALLINT   := 2;  -- .5
+  _point  SMALLINT   := 3;  -- .6
+  _qual   SMALLINT   := 4;  -- beta
+  _qualn  SMALLINT   := 5;  -- 2
+  _subq   SMALLINT   := 6;  -- A
 BEGIN
+  CASE WHEN _left[_major] > _right[_major] THEN _result :=  1;
+       WHEN _left[_major] < _right[_major] THEN _result := -1;
+       WHEN _left[_minor] > _right[_minor] THEN _result :=  1;
+       WHEN _left[_minor] < _right[_minor] THEN _result := -1;
+       WHEN _left[_patch] > _right[_patch] THEN _result :=  1;
+       WHEN _left[_patch] < _right[_patch] THEN _result := -1;
+       WHEN _left[_qual]  > _right[_qual]  THEN _result :=  1;
+       WHEN _left[_qual]  < _right[_qual]  THEN _result := -1;
+       WHEN _left[_qualn] > _right[_qualn] THEN _result :=  1;
+       WHEN _left[_qualn] < _right[_qualn] THEN _result := -1;
+       WHEN _left[_subq]  > _right[_subq]  THEN _result :=  1;
+       WHEN _left[_subq]  < _right[_subq]  THEN _result := -1;
+       WHEN _left[_subq]  = _right[_subq]  THEN _result :=  0;
+  END CASE;
 
--- left
-SELECT  substring(_leftVersion FROM $$(\d+)\.\d+\.\d+$$)::SMALLINT, 
-	substring(_leftVersion FROM $$\d+\.(\d+)\.\d+$$)::SMALLINT, 
-	substring(_leftVersion FROM $$\d+\.\d+\.(\d+)$$)::SMALLINT 
-	INTO _leftMajor, _leftMinor, _leftPatch;
-
-IF (DEBUG)
-  THEN RAISE NOTICE 'Left Version --> % Major --> % Minor --> % Patch --> % ', _leftVersion, _leftMajor, _leftMinor, _leftPatch;
-END IF;
-
--- right
-SELECT  substring(_rightVersion FROM $$(\d+)\.\d+\.\d+$$)::SMALLINT, 
-	substring(_rightVersion FROM $$\d+\.(\d+)\.\d+$$)::SMALLINT, 
-	substring(_rightVersion FROM $$\d+\.\d+\.(\d+)$$)::SMALLINT 
-	INTO _rightMajor, _rightMinor, _rightPatch;
-
-IF (DEBUG)
- THEN RAISE NOTICE 'Right Version --> % Major --> % Minor --> % Patch --> % ', _rightVersion, _rightMajor, _rightMinor, _rightPatch;
-END IF;
-
--- check major version
-IF (_leftMajor > _rightMajor) THEN _returnCode := 1;
-ELSIF (_leftMajor < _rightMajor) THEN _returnCode := -1;
-ELSIF (_leftMajor = _rightMajor) THEN
-  -- if major is equal, check minor version
-  IF (_leftMinor > _rightMinor) THEN _returnCode := 1;
-  ELSIF (_leftMinor < _rightMinor) THEN _returnCode := -1;
-  ELSIF (_leftMinor = _rightMinor) THEN
-    -- if major and minor are equal, check patch version
-    IF (_leftPatch > _rightPatch) THEN _returnCode := 1;
-    ELSIF (_leftPatch < _rightPatch) THEN _returnCode := -1;
-    ELSIF (_leftPatch = _rightPatch) THEN _returnCode := 0;
-    END IF;
-  END IF;
--- if we somehow don't match those three operators it probably means someone passed in a version that wasn't in numerical major.minor.patch format
-ELSE RAISE EXCEPTION 'One or more of the version parameters is invalid. Expected numerical Major.Minor.Patch version string. Left --> % Right --> %', _leftVersion, _rightVersion;
-END IF;
-
-RETURN _returnCode;
+  RETURN _result;
 
 END;
-$BODY$
-  LANGUAGE plpgsql STABLE;
-ALTER FUNCTION public.compareversion(text, text)
-  OWNER TO admin;
+$$ LANGUAGE plpgsql STABLE;
+ALTER FUNCTION public.compareversion(text, text) OWNER TO admin;

--- a/foundation-database/public/functions/compareversion.sql
+++ b/foundation-database/public/functions/compareversion.sql
@@ -22,8 +22,8 @@ BEGIN
        WHEN _left[_major] < _right[_major] THEN _result := -1;
        WHEN _left[_minor] > _right[_minor] THEN _result :=  1;
        WHEN _left[_minor] < _right[_minor] THEN _result := -1;
-       WHEN _left[_patch] > _right[_patch] THEN _result :=  1;
-       WHEN _left[_patch] < _right[_patch] THEN _result := -1;
+       WHEN _left[_point] > _right[_point] THEN _result :=  1;
+       WHEN _left[_point] < _right[_point] THEN _result := -1;
        WHEN _left[_qual]  > _right[_qual]  THEN _result :=  1;
        WHEN _left[_qual]  < _right[_qual]  THEN _result := -1;
        WHEN _left[_qualn] > _right[_qualn] THEN _result :=  1;

--- a/test/database/functions/.jshint
+++ b/test/database/functions/.jshint
@@ -1,0 +1,30 @@
+{
+  "bitwise":    true,
+  "curly":      true,
+  "eqeqeq":     true,
+  "forin":      true,
+  "immed":      true,
+  "indent":     2,
+  "latedef":    true,
+  "maxlen":     90,
+  "newcap":     true,
+  "noarg":      true,
+  "strict":     true,
+  "trailing":   true,
+  "undef":      true,
+  "unused":     true,
+  "white":      true,
+
+  "predef": [
+    "XT",
+    "__dirname",
+    "after",
+    "before",
+    "console",
+    "describe",
+    "exports",
+    "it",
+    "require"
+  ]
+
+}

--- a/test/database/functions/compareversion.js
+++ b/test/database/functions/compareversion.js
@@ -1,0 +1,124 @@
+var _ = require("underscore"),
+  assert = require('chai').assert,
+  path = require('path');
+
+(function () {
+  "use strict";
+  describe('compareVersion()', function () {
+
+    var loginData = require(path.join(__dirname, "../../lib/login_data.js")).data,
+      datasource = require('../../../node-datasource/lib/ext/datasource').dataSource,
+      config = require(path.join(__dirname, "../../../node-datasource/config.js")),
+      creds = _.extend({}, config.databaseServer, {database: loginData.org});
+
+    it("should return negative for PG version older than current", function (done) {
+      var sql = "select compareVersion('7.0') as result;";
+      datasource.query(sql, creds, function (err, res) {
+        assert.equal(res.rows[0].result, -1);
+        done();
+      });
+    });
+
+    it("should return positive for PG version newer than current", function (done) {
+      var sql = "select compareVersion('15.0') as result;";
+      datasource.query(sql, creds, function (err, res) {
+        assert.equal(res.rows[0].result, 1);
+        done();
+      });
+    });
+
+    it("should return negative for PG version older than current", function (done) {
+      var sql = "select compareVersion('7.0') as result;";
+      datasource.query(sql, creds, function (err, res) {
+        assert.equal(res.rows[0].result, -1);
+        done();
+      });
+    });
+
+    it("should compare 2 major version numbers", function (done) {
+      var sql = "select compareVersion('4.5.5', '5.5.7') as lt," +
+                "       compareVersion('4.5.6', '4.5.6') as eq," +
+                "       compareVersion('5.5.7', '4.5.5') as gt;";
+      datasource.query(sql, creds, function (err, res) {
+        assert.equal(res.rows[0].lt, -1);
+        assert.equal(res.rows[0].eq,  0);
+        assert.equal(res.rows[0].gt,  1);
+        done();
+      });
+    });
+
+    it("should compare 2 minor version numbers", function (done) {
+      var sql = "select compareVersion('4.5.5', '4.6.7') as lt," +
+                "       compareVersion('4.5.6', '4.5.6') as eq," +
+                "       compareVersion('4.6.7', '4.5.5') as gt;";
+      datasource.query(sql, creds, function (err, res) {
+        assert.equal(res.rows[0].lt, -1);
+        assert.equal(res.rows[0].eq,  0);
+        assert.equal(res.rows[0].gt,  1);
+        done();
+      });
+    });
+
+    it("should compare 2 point version numbers", function (done) {
+      var sql = "select compareVersion('4.5.5', '4.5.7') as lt," +
+                "       compareVersion('4.5.6', '4.5.6') as eq," +
+                "       compareVersion('4.5.7', '4.5.5') as gt;";
+      datasource.query(sql, creds, function (err, res) {
+        assert.equal(res.rows[0].lt, -1);
+        assert.equal(res.rows[0].eq,  0);
+        assert.equal(res.rows[0].gt,  1);
+        done();
+      });
+    });
+
+    it("should handle transition from 1 to 2 digit numbers", function (done) {
+      var sql = "select compareVersion('4.9.5',  '4.10.7') as lt," +
+                "       compareVersion('4.10.7', '4.9.5')  as gt;";
+      datasource.query(sql, creds, function (err, res) {
+        assert.equal(res.rows[0].lt, -1);
+        assert.equal(res.rows[0].gt,  1);
+        done();
+      });
+    });
+
+    it("should handle xTuple-style", function (done) {
+      var sql = "select compareVersion('4.5.5Alpha',  '4.5.7Alpha2') as lt1," +
+                "       compareVersion('4.5.6Alpha2', '4.5.6Beta')   as lt2," +
+                "       compareVersion('4.5.6Beta',   '4.5.6Beta2')  as lt3," +
+                "       compareVersion('4.5.6Beta2',  '4.5.6RC')     as lt4," +
+                "       compareVersion('4.5.6RC',     '4.5.6')       as lt5," +
+                "       compareVersion('4.5.6',       '4.5.7')       as lt6 " +
+                "       ;";
+      datasource.query(sql, creds, function (err, res) {
+        assert.equal(res.rows[0].lt1, -1, "alpha vs. alpha2");
+        assert.equal(res.rows[0].lt2, -1, "alpha2 vs. beta");
+        assert.equal(res.rows[0].lt3, -1, "beta vs. beta2");
+        assert.equal(res.rows[0].lt4, -1, "beta2 vs. rc");
+        assert.equal(res.rows[0].lt5, -1, "rc vs. final");
+        assert.equal(res.rows[0].lt6, -1, "final vs. next final");
+        done();
+      });
+    });
+
+    it("should handle semver", function (done) {
+      var sql = "select compareVersion('4.5.5-alpha',   '4.5.7-alpha.2') as lt1," +
+                "       compareVersion('4.5.6-alpha.2', '4.5.6-beta')    as lt2," +
+                "       compareVersion('4.5.6-beta',    '4.5.6-beta.2')  as lt3," +
+                "       compareVersion('4.5.6-beta.2',  '4.5.6-RC')      as lt4," +
+                "       compareVersion('4.5.6-RC',      '4.5.6')         as lt5," +
+                "       compareVersion('4.5.6',         '4.5.7')         as lt6 " +
+                "       ;";
+      datasource.query(sql, creds, function (err, res) {
+        assert.equal(res.rows[0].lt1, -1, "alpha vs. alpha2");
+        assert.equal(res.rows[0].lt2, -1, "alpha2 vs. beta");
+        assert.equal(res.rows[0].lt3, -1, "beta vs. beta2");
+        assert.equal(res.rows[0].lt4, -1, "beta2 vs. rc");
+        assert.equal(res.rows[0].lt5, -1, "rc vs. final");
+        assert.equal(res.rows[0].lt6, -1, "final vs. next final");
+        done();
+      });
+    });
+
+
+  });
+}());

--- a/test/database/functions/compareversion.js
+++ b/test/database/functions/compareversion.js
@@ -14,6 +14,7 @@ var _ = require("underscore"),
     it("should return negative for PG version older than current", function (done) {
       var sql = "select compareVersion('7.0') as result;";
       datasource.query(sql, creds, function (err, res) {
+        assert.isNull(err);
         assert.equal(res.rows[0].result, -1);
         done();
       });

--- a/test/database/functions/compareversion.js
+++ b/test/database/functions/compareversion.js
@@ -23,6 +23,7 @@ var _ = require("underscore"),
     it("should return positive for PG version newer than current", function (done) {
       var sql = "select compareVersion('15.0') as result;";
       datasource.query(sql, creds, function (err, res) {
+        assert.isNull(err);
         assert.equal(res.rows[0].result, 1);
         done();
       });
@@ -31,6 +32,7 @@ var _ = require("underscore"),
     it("should return negative for PG version older than current", function (done) {
       var sql = "select compareVersion('7.0') as result;";
       datasource.query(sql, creds, function (err, res) {
+        assert.isNull(err);
         assert.equal(res.rows[0].result, -1);
         done();
       });
@@ -41,6 +43,7 @@ var _ = require("underscore"),
                 "       compareVersion('4.5.6', '4.5.6') as eq," +
                 "       compareVersion('5.5.7', '4.5.5') as gt;";
       datasource.query(sql, creds, function (err, res) {
+        assert.isNull(err);
         assert.equal(res.rows[0].lt, -1);
         assert.equal(res.rows[0].eq,  0);
         assert.equal(res.rows[0].gt,  1);
@@ -53,6 +56,7 @@ var _ = require("underscore"),
                 "       compareVersion('4.5.6', '4.5.6') as eq," +
                 "       compareVersion('4.6.7', '4.5.5') as gt;";
       datasource.query(sql, creds, function (err, res) {
+        assert.isNull(err);
         assert.equal(res.rows[0].lt, -1);
         assert.equal(res.rows[0].eq,  0);
         assert.equal(res.rows[0].gt,  1);
@@ -65,6 +69,7 @@ var _ = require("underscore"),
                 "       compareVersion('4.5.6', '4.5.6') as eq," +
                 "       compareVersion('4.5.7', '4.5.5') as gt;";
       datasource.query(sql, creds, function (err, res) {
+        assert.isNull(err);
         assert.equal(res.rows[0].lt, -1);
         assert.equal(res.rows[0].eq,  0);
         assert.equal(res.rows[0].gt,  1);
@@ -76,6 +81,7 @@ var _ = require("underscore"),
       var sql = "select compareVersion('4.9.5',  '4.10.7') as lt," +
                 "       compareVersion('4.10.7', '4.9.5')  as gt;";
       datasource.query(sql, creds, function (err, res) {
+        assert.isNull(err);
         assert.equal(res.rows[0].lt, -1);
         assert.equal(res.rows[0].gt,  1);
         done();
@@ -91,6 +97,7 @@ var _ = require("underscore"),
                 "       compareVersion('4.5.6',       '4.5.7')       as lt6 " +
                 "       ;";
       datasource.query(sql, creds, function (err, res) {
+        assert.isNull(err);
         assert.equal(res.rows[0].lt1, -1, "alpha vs. alpha2");
         assert.equal(res.rows[0].lt2, -1, "alpha2 vs. beta");
         assert.equal(res.rows[0].lt3, -1, "beta vs. beta2");
@@ -110,6 +117,7 @@ var _ = require("underscore"),
                 "       compareVersion('4.5.6',         '4.5.7')         as lt6 " +
                 "       ;";
       datasource.query(sql, creds, function (err, res) {
+        assert.isNull(err);
         assert.equal(res.rows[0].lt1, -1, "alpha vs. alpha2");
         assert.equal(res.rows[0].lt2, -1, "alpha2 vs. beta");
         assert.equal(res.rows[0].lt3, -1, "beta vs. beta2");


### PR DESCRIPTION
Issue #24213: Revised compare version function

The new version should be callable from the Updater to compare package versions and from updater packages themselves in version number prerequisite checks. Thus
```sql
select not fetchMetricText('ServerVersion') > '4.9.0';
```
can be replaced with
```sql
select compareVersion(fetchMetricText('ServerVersion'), '4.9.0') = -1;
```
The new select is a little longer but avoids the `<` encoding issue. It also handles alpha/beta/rc/final queries and transitions between X.9.Y and X.10.0.