### PR TITLE
2207 refresh activity list

### DIFF
--- a/enyo-client/application/source/views/list.js
+++ b/enyo-client/application/source/views/list.js
@@ -80,7 +80,8 @@ trailing:true, white:true, strict: false*/
     collection: "XM.ActivityListItemCollection",
     parameterWidget: "XV.ActivityListParameters",
     published: {
-      activityActions: []
+      activityActions: [],
+      alwaysRefresh: true
     },
     actions: [
       {name: "reassignUser",

--- a/enyo-client/application/source/views/list.js
+++ b/enyo-client/application/source/views/list.js
@@ -81,7 +81,7 @@ trailing:true, white:true, strict: false*/
     parameterWidget: "XV.ActivityListParameters",
     published: {
       activityActions: [],
-      alwaysRefresh: true
+      alwaysRefetch: true
     },
     actions: [
       {name: "reassignUser",

--- a/enyo-client/extensions/source/project/client/widgets/parameter.js
+++ b/enyo-client/extensions/source/project/client/widgets/parameter.js
@@ -15,7 +15,7 @@ trailing:true, white:true, strict:false*/
     XV.ActivityListParameters.prototype.activityTypes.project = [
       {type: "Project"},
       {type: "ProjectTask", label: "_tasks".loc()},
-      {type: "ProjectWorkflow", label: "_workflow".loc()}
+      {type: "ProjectWorkflow", label: "_projectWorkflow".loc()}
     ];
  
     // ..........................................................

--- a/enyo-client/extensions/source/purchasing/client/en/strings.js
+++ b/enyo-client/extensions/source/purchasing/client/en/strings.js
@@ -40,7 +40,7 @@ strict:true, trailing:true, white:true */
     "_purchaseEmailProfiles": "Purchase Email",
     "_purchaseOrder": "Purchase Order",
     "_purchaseOrderLine": "Purchase Order Line",
-    "_purchaseOrderWorkflow": "Purchase Workflow",
+    "_purchaseOrderWorkflow": "Purchase Order Workflow",
     "_purchaseOrders": "Purchase Orders",
     "_purchaseRequest": "Purchase Request",
     "_purchaseRequests": "Purchase Requests",

--- a/enyo-client/extensions/source/purchasing/client/widgets/parameter.js
+++ b/enyo-client/extensions/source/purchasing/client/widgets/parameter.js
@@ -13,7 +13,7 @@ trailing:true, white:true, strict: false*/
 
     XV.ActivityListParameters.prototype.activityTypes.purchasing = [
       {type: "PurchaseOrder", label: "_purchaseOrders".loc()},
-      {type: "PurchaseOrderWorkflow", label: "_workflow".loc()}
+      {type: "PurchaseOrderWorkflow", label: "_purchaseOrderWorkflow".loc()}
     ];
 
     // ..........................................................

--- a/enyo-client/extensions/source/sales/client/en/strings.js
+++ b/enyo-client/extensions/source/sales/client/en/strings.js
@@ -59,6 +59,7 @@ strict:true, trailing:true, white:true */
     "_salesOrder": "Sales Order",
     "_salesOrderAck": "Sales Order Acknowledgement",
     "_salesOrdersNext30Days": "Sales Orders Next 30 Days",
+    "_salesOrderWorkflow": "Sales Order Workflow",
     "_scheduled": "Scheduled",
     "_scheduledDate": "Scheduled Date",
     "_shipControl": "Ship Control",

--- a/enyo-client/extensions/source/sales/client/widgets/parameter.js
+++ b/enyo-client/extensions/source/sales/client/widgets/parameter.js
@@ -13,7 +13,7 @@ trailing:true, white:true*/
 
     XV.ActivityListParameters.prototype.activityTypes.sales = [
       {type: "SalesOrder", label: "_salesOrders".loc()},
-      {type: "SalesOrderWorkflow", label: "_orderWorkflow".loc()}
+      {type: "SalesOrderWorkflow", label: "_salesOrderWorkflow".loc()}
     ];
 
     // ..........................................................

--- a/lib/enyo-x/source/views/list.js
+++ b/lib/enyo-x/source/views/list.js
@@ -79,7 +79,7 @@ trailing:true, white:true, strict:false*/
         a collection of the filtered result set, otherwise it is the
         regular collection backing the list.
       */
-      filtered: null,
+      filtered: null
     },
     events: {
       onExportList: "",

--- a/lib/enyo-x/source/views/list_base.js
+++ b/lib/enyo-x/source/views/list_base.js
@@ -20,7 +20,7 @@ trailing:true, white:true, strict:false*/
     kind: "List",
     published: {
       actions: null,
-      alwaysRefresh: false,
+      alwaysRefetch: false,
       headerComponents: null
     },
     events: {
@@ -36,6 +36,7 @@ trailing:true, white:true, strict:false*/
       onModelChange: "modelChanged",
       onChange: "selectionChanged",
       onSetupItem: "setupItem",
+      onRefetchList: "refetchList"
     },
     /**
       A list item has been selected. Delegate to the method cited
@@ -116,8 +117,10 @@ trailing:true, white:true, strict:false*/
 
         this.refreshModel(inEvent.id, inEvent.done);
       }
+    },
+    refetchList: function (inSender, inEvent) {
       // ex. XV.ActivityList re: https://github.com/xtuple/xtuple/issues/2207
-      if (this.alwaysRefresh) {
+      if (this.alwaysRefetch) {
         this.fetch();       
       }
     },

--- a/lib/enyo-x/source/views/list_base.js
+++ b/lib/enyo-x/source/views/list_base.js
@@ -20,6 +20,7 @@ trailing:true, white:true, strict:false*/
     kind: "List",
     published: {
       actions: null,
+      alwaysRefresh: false,
       headerComponents: null
     },
     events: {
@@ -114,6 +115,10 @@ trailing:true, white:true, strict:false*/
           value && typeof Klass === "function") {
 
         this.refreshModel(inEvent.id, inEvent.done);
+      }
+      // ex. XV.ActivityList re: https://github.com/xtuple/xtuple/issues/2207
+      if (this.alwaysRefresh) {
+        this.fetch();       
       }
     },
     refreshModel: function (id, afterDone) {

--- a/lib/enyo-x/source/views/list_base.js
+++ b/lib/enyo-x/source/views/list_base.js
@@ -121,7 +121,7 @@ trailing:true, white:true, strict:false*/
     refetchList: function (inSender, inEvent) {
       // ex. XV.ActivityList re: https://github.com/xtuple/xtuple/issues/2207
       if (this.alwaysRefetch) {
-        this.fetch();       
+        this.fetch();
       }
     },
     refreshModel: function (id, afterDone) {

--- a/lib/enyo-x/source/views/module_container.js
+++ b/lib/enyo-x/source/views/module_container.js
@@ -445,7 +445,7 @@ trailing:true, white:true*/
       be the last one, so we can simply go "back" to it coming
       back out of a workspace.
      */
-    previous: function (options) {
+    previous: function (inSender, inEvent) {
       // Stock implementation is screwy, do our own
       var last = this.getActive(),
         previous = this.index - 1,
@@ -456,7 +456,7 @@ trailing:true, white:true*/
       active = this.getActive();
       active.waterfallDown("onActivatePanel", {activated: active});
       // Refetch the previous list
-      if (options.refetch) {
+      if (inEvent.refetch) {
         active.waterfallDown("onRefetchList");
       }
       last.destroy();

--- a/lib/enyo-x/source/views/module_container.js
+++ b/lib/enyo-x/source/views/module_container.js
@@ -445,7 +445,7 @@ trailing:true, white:true*/
       be the last one, so we can simply go "back" to it coming
       back out of a workspace.
      */
-    previous: function () {
+    previous: function (options) {
       // Stock implementation is screwy, do our own
       var last = this.getActive(),
         previous = this.index - 1,
@@ -455,7 +455,10 @@ trailing:true, white:true*/
       // Provide a way to let panels or their children know they have been activated
       active = this.getActive();
       active.waterfallDown("onActivatePanel", {activated: active});
-
+      // Refetch the previous list
+      if (options.refetch) {
+        active.waterfallDown("onRefetchList");
+      }
       last.destroy();
     },
     popupWorkspaceNotify: function (inSender, inEvent) {

--- a/lib/enyo-x/source/views/module_container.js
+++ b/lib/enyo-x/source/views/module_container.js
@@ -92,6 +92,10 @@ trailing:true, white:true*/
     addTransactionList: function (inSender, inEvent) {
       var panel = this.createComponent({kind: inEvent.kind}),
         order = panel.$.parameterWidget.$.order;
+      // Set the model for use later with the onModelChange event handling so that the origin list
+      // gets updated properly.
+      inEvent.model.orderModelName = inEvent.orderModelName;
+      panel.setTransactionOriginModel(inEvent.model);
 
       panel.setCallback(inEvent.callback);
       panel.render();

--- a/lib/enyo-x/source/views/module_container.js
+++ b/lib/enyo-x/source/views/module_container.js
@@ -456,7 +456,7 @@ trailing:true, white:true*/
       active = this.getActive();
       active.waterfallDown("onActivatePanel", {activated: active});
       // Refetch the previous list
-      if (inEvent.refetch) {
+      if (inEvent && inEvent.refetch) {
         active.waterfallDown("onRefetchList");
       }
       last.destroy();

--- a/lib/enyo-x/source/views/module_container.js
+++ b/lib/enyo-x/source/views/module_container.js
@@ -92,7 +92,7 @@ trailing:true, white:true*/
     addTransactionList: function (inSender, inEvent) {
       var panel = this.createComponent({kind: inEvent.kind}),
         order = panel.$.parameterWidget.$.order;
-      
+
       panel.setCallback(inEvent.callback);
       panel.render();
       this.reflow();

--- a/lib/enyo-x/source/views/module_container.js
+++ b/lib/enyo-x/source/views/module_container.js
@@ -92,11 +92,7 @@ trailing:true, white:true*/
     addTransactionList: function (inSender, inEvent) {
       var panel = this.createComponent({kind: inEvent.kind}),
         order = panel.$.parameterWidget.$.order;
-      // Set the model for use later with the onModelChange event handling so that the origin list
-      // gets updated properly.
-      inEvent.model.orderModelName = inEvent.orderModelName;
-      panel.setTransactionOriginModel(inEvent.model);
-
+      
       panel.setCallback(inEvent.callback);
       panel.render();
       this.reflow();

--- a/lib/enyo-x/source/views/navigator.js
+++ b/lib/enyo-x/source/views/navigator.js
@@ -1023,7 +1023,7 @@ trailing:true*/
       if (panel.getFilterDescription) {
         this.setHeaderContent(panel.getFilterDescription());
       }
-      if (panel.alwaysRefresh || (panel.fetch && !this.fetched[panelIndex])) {
+      if (panel.alwaysRefetch || (panel.fetch && !this.fetched[panelIndex])) {
         this.fetch();
         this.fetched[panelIndex] = true;
       }

--- a/lib/enyo-x/source/views/navigator.js
+++ b/lib/enyo-x/source/views/navigator.js
@@ -1023,7 +1023,7 @@ trailing:true*/
       if (panel.getFilterDescription) {
         this.setHeaderContent(panel.getFilterDescription());
       }
-      if (panel.fetch && !this.fetched[panelIndex]) {
+      if (panel.alwaysRefresh || (panel.fetch && !this.fetched[panelIndex])) {
         this.fetch();
         this.fetched[panelIndex] = true;
       }

--- a/lib/enyo-x/source/views/transaction_list_container.js
+++ b/lib/enyo-x/source/views/transaction_list_container.js
@@ -89,9 +89,9 @@ trailing:true, white:true, strict:false*/
     },
     close: function () {
       var callback = this.getCallback();
-      // Pass this empty event to be handled by XV.ListBase which will re-fetch the list if req'd.
-      this.doModelChange();
-      this.doPrevious();
+      // TODO - replace this with missing doModelChange events during line item (i.e. IssueStock) &
+      // order posting transactions https://mobile.xtuple.com/dogfood/app#workspace/incident/25480
+      this.doPrevious({refetch: true});
       if (callback) { callback(); }
     },
     buildMenu: function () {

--- a/lib/enyo-x/source/views/transaction_list_container.js
+++ b/lib/enyo-x/source/views/transaction_list_container.js
@@ -17,7 +17,6 @@ trailing:true, white:true, strict:false*/
     kind: "XV.SearchPanels",
     classes: 'xv-search',
     published: {
-      transOriginModel: null,
       prerequisite: "",
       notifyMessage: "",
       list: null,
@@ -89,15 +88,9 @@ trailing:true, white:true, strict:false*/
       this[method](inSender, inEvent);
     },
     close: function () {
-      var callback = this.getCallback(),
-        transOriginModel = this.getTransOriginModel();
-
-      if (transOriginModel) {
-        this.doModelChange({
-          model: transOriginModel.orderModelName,
-          id: transOriginModel.id
-        });
-      }
+      var callback = this.getCallback();
+      // Pass this empty event to be handled by XV.ListBase which will re-fetch the list if req'd.
+      this.doModelChange();
       this.doPrevious();
       if (callback) { callback(); }
     },

--- a/lib/enyo-x/source/views/transaction_list_container.js
+++ b/lib/enyo-x/source/views/transaction_list_container.js
@@ -17,6 +17,7 @@ trailing:true, white:true, strict:false*/
     kind: "XV.SearchPanels",
     classes: 'xv-search',
     published: {
+      transOriginModel: null,
       prerequisite: "",
       notifyMessage: "",
       list: null,
@@ -27,7 +28,8 @@ trailing:true, white:true, strict:false*/
     },
     events: {
       onPrevious: "",
-      onWorkspace: ""
+      onWorkspace: "",
+      onModelChange: ""
     },
     handlers: {
       onListItemMenuTap: "showListItemMenu",
@@ -87,8 +89,15 @@ trailing:true, white:true, strict:false*/
       this[method](inSender, inEvent);
     },
     close: function () {
-      var callback = this.getCallback();
+      var callback = this.getCallback(),
+        transOriginModel = this.getTransOriginModel();
 
+      if (transOriginModel) {
+        this.doModelChange({
+          model: transOriginModel.orderModelName,
+          id: transOriginModel.id
+        });
+      }
       this.doPrevious();
       if (callback) { callback(); }
     },


### PR DESCRIPTION
- Added an `alwaysRefetch` published value and set it to true on the Activity List so that every time it's rendered in the client it re-fetches. The onModelChange event used to "refresh" lists is not working here - transactional enyo views would need a lot of work to add the missing functionality, thus this `alwaysRefetch` solution.
- Renamed the _workflow_ labels in the Activity List parameter widget

UAT:
*on a db with workflow setup 
1. Access the activity list from sales module (so that it fetches for the first time as normal, this still takes a long time).
2. Go back to Sales Order list, add a sales order
3. Go back to activity list and see that the sales order should now appear in the list
4. Tap on `Issue to Shipping` workflow for the sales order that was created, issue all line items quantities
5. Tap back to go back to activity list. The list should have re-fetched and removed the completed Issue to Shipping workflow item and added the next `Ship` workflow item for that sales order.