### PR TITLE
Issue #25072: Purchased xTuple licenses are consumed by non xTuple DB connections

### DIFF
--- a/foundation-database/public/functions/numofserverusers.sql
+++ b/foundation-database/public/functions/numofserverusers.sql
@@ -1,5 +1,5 @@
-
-CREATE OR REPLACE FUNCTION numOfServerUsers() RETURNS INTEGER AS '
+﻿
+CREATE OR REPLACE FUNCTION numOfServerUsers() RETURNS INTEGER AS $$
 -- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple. 
 -- See www.xtuple.com/CPAL for the full text of the software license.
 DECLARE
@@ -8,7 +8,7 @@ DECLARE
 BEGIN
 
   SELECT COUNT(*) INTO _count
-  FROM pg_stat_activity;
+  FROM pg_stat_activity WHERE datname = current_database();
   IF (_count IS NULL) THEN
     _count := 0;
   END IF;
@@ -16,5 +16,5 @@ BEGIN
   RETURN _count;
 
 END;
-' LANGUAGE 'plpgsql';
+$$ LANGUAGE 'plpgsql';
 


### PR DESCRIPTION
This pull request addresses part of the problems describe in Issue #25072. It also compliments and is required by PR xtuple/qt-client#625.

The *numOfDatabaseUsers* function has been revised to perform connection counting against the "application_name" assigned to the database connection. An overload has been provided to retain backwards compatibility, though a scan of the major repositories showed no references to this stored procedure except for in the qt-client.

The "numOfServerUsers" function has been updated to count only connections for the active database which compliments the established licensing rules and clarifies the connection count reporting displayed by the **System** > **Setup** > **Database** screen.
