### PR TITLE
Issue #24608: Allow creation of CM when posting payments inside SOs

### DIFF
--- a/foundation-database/public/trigger_functions/aropen.sql
+++ b/foundation-database/public/trigger_functions/aropen.sql
@@ -15,6 +15,7 @@ BEGIN
   -- Start with privileges
   IF ( (NOT checkPrivilege('MaintainARMemos')) AND
        (NOT checkPrivilege('PostMiscInvoices')) AND
+       (NOT checkPrivilege('MaintainSalesOrders')) AND -- #24608 Required to post payments on SOs
        (NOT checkPrivilege('PostARDocuments')) ) THEN
     RAISE EXCEPTION 'You do not have privileges to maintain A/R Memos.';
   END IF;


### PR DESCRIPTION
Resolves issue where user able to process payments in a Sales Order cannot complete the transaction due to missing privileges when creating the AR Credit memo.

This resolves both Credit Card and Cash payments