### PR TITLE
Account is not nested. Should be just nkey, not sub prop.

### DIFF
--- a/database/orm/models/contact.json
+++ b/database/orm/models/contact.json
@@ -844,7 +844,7 @@
         "delete": false,
         "properties": [
           "owner.username",
-          "account.number"
+          "account"
         ]
       }
     },


### PR DESCRIPTION
This fixes a bug when querying the `XM.ContactRelation` object using share user access. The permission check was looking for a nested object property `account.number`, but this is not a nested object, only the natural key is available, so the permission check should just be for `account`.

See different between `owner` and `account` on `XM.ContactRelation`.