### PR TITLE
Issue #24589: Handle doc number release when Quotes use SO numbering

### DIFF
--- a/foundation-database/public/functions/releasenumber.sql
+++ b/foundation-database/public/functions/releasenumber.sql
@@ -46,7 +46,7 @@ BEGIN
     -- Check if order seq has been incremented past the given order number
     -- Problem occurred with open but not saved orders (i.e. open by two or more people
     -- at the same time) so need to check for that as well.
-    IF ((FOUND AND ((_test - 1) > pnumber)) 
+    IF ((FOUND AND (_test > pnumber))
           OR ((_test IS NULL) AND ((_number - 1) > pnumber))
           OR (_number = pnumber)) THEN
       RETURN 0;


### PR DESCRIPTION
Resolve another use-case scenario around multiple open documents and their numbering