### PR TITLE
Issue #12336: Add SO Hold Type override privilege

### DIFF
--- a/foundation-database/public/tables/priv.sql
+++ b/foundation-database/public/tables/priv.sql
@@ -1,4 +1,3 @@
-insert into priv (priv_module, priv_name, priv_descrip)
-select 'Accounting', 'ChangeCashRecvPostDate',
-       'Can change the distribution date when posting Cash Receipts'
-where not exists (select c.priv_id from priv c where c.priv_name = 'ChangeCashRecvPostDate');
+select createpriv('Accounting', 'ChangeCashRecvPostDate', 'Can change the distribution date when posting Cash Receipts');
+select createpriv('Sales', 'OverrideSOHoldType', 'Allowed to override the Sales Order Hold Type');
+


### PR DESCRIPTION
Add separate privilege to SO hold type to allow user to create a SO but not necessarily override customer credit hold

Requires xtuple/qt-client#647