### PR TITLE
Issue #25612: Add Sale Type default checkbox to set up to fix SO bug

### DIFF
--- a/foundation-database/manifest.js
+++ b/foundation-database/manifest.js
@@ -1043,6 +1043,7 @@
     "public/tables/metric.sql",
     "public/tables/payco.sql",
     "public/tables/priv.sql",
+    "public/tables/saletype.sql",
     "public/tables/tax.sql",
     "public/tables/taxpay.sql",
 

--- a/foundation-database/public/tables/metasql/saletype-table.mql
+++ b/foundation-database/public/tables/metasql/saletype-table.mql
@@ -1,7 +1,7 @@
 -- Group: saletype
 -- Name: table
 -- Notes: maintain saletype table
--- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+-- Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
 
 <? if exists("CheckMode") ?>
@@ -32,18 +32,21 @@
   INSERT INTO saletype
     ( saletype_code,
       saletype_descr,
-      saletype_active )
+      saletype_active,
+      saletype_default )
   VALUES
     ( UPPER(<? value("saletype_code") ?>),
       <? value("saletype_descr") ?>,
-      <? value("saletype_active") ?> )
+      <? value("saletype_active") ?>,
+      <? value("saletype_default") ?> )
   RETURNING saletype_id;
 
 <? elseif exists("EditMode") ?>
   UPDATE saletype
     SET saletype_code=UPPER(<? value("saletype_code") ?>),
         saletype_descr=<? value("saletype_descr") ?>,
-        saletype_active=<? value("saletype_active") ?>
+        saletype_active=<? value("saletype_active") ?>,
+        saletype_default=<? value("saletype_default") ?>
   WHERE (saletype_id=<? value("saletype_id") ?>);
 
 <? elseif exists("DeleteMode") ?>

--- a/foundation-database/public/tables/saletype.sql
+++ b/foundation-database/public/tables/saletype.sql
@@ -1,0 +1,1 @@
+SELECT xt.add_column('saletype', 'saletype_default', 'BOOLEAN', NULL::TEXT, 'public');

--- a/foundation-database/public/tables/saletype.sql
+++ b/foundation-database/public/tables/saletype.sql
@@ -1,1 +1,1 @@
-SELECT xt.add_column('saletype', 'saletype_default', 'BOOLEAN', NULL::TEXT, 'public');
+SELECT xt.add_column('saletype', 'saletype_default', 'BOOLEAN', 'NOT NULL DEFAULT FALSE', 'public');


### PR DESCRIPTION
SO defaulted to first alphabetically listed Sale Type when not manually set.  This could change if Sale Types were updated.

Must be merged together with xtuple/xtuple#2261
Required by xtuple/qt-client#649