### PR TITLE
resolves issue #2264 - make transaction lists draggable

### DIFF
--- a/lib/enyo-x/source/layout/panels.js
+++ b/lib/enyo-x/source/layout/panels.js
@@ -158,6 +158,9 @@ trailing:true*/
     name: 'XV.SearchPanels',
     kind: 'XV.GridPanels',
     classes: 'xv-app-panel-container',
+    arrangerKind: "CollapsingArranger",
+    draggable: true,
+    realtimeFit: true,
     controlClasses: 'xv-app-panel'
   });
 

--- a/lib/enyo-x/source/views/navigator.js
+++ b/lib/enyo-x/source/views/navigator.js
@@ -149,7 +149,7 @@ trailing:true*/
         {name: "header", classes: "xv-header"},
         {name: "contentHeader"},
         {name: "contentPanels", kind: "Panels", margin: 0, fit: true,
-          draggable: false, panelCount: 0, classes: "scroll-ios"},
+          draggable: false, panelCount: 0, classes: "scroll-ios xv-content-panel"},
         {name: "myAccountPopup", kind: "XV.MyAccountPopup"},
         {name: "listItemMenu", kind: "onyx.Menu", floating: true, onSelect: "listActionSelected",
           maxHeight: 500, components: []

--- a/lib/enyo-x/source/views/search.js
+++ b/lib/enyo-x/source/views/search.js
@@ -55,6 +55,7 @@ trailing:true, white:true*/
         // the onyx-menu-toolbar class keeps the popups from being hidden
         {kind: "onyx.MoreToolbar", name: "contentToolbar",
           classes: "onyx-menu-toolbar", movedClass: "xv-toolbar-moved", components: [
+          {kind: "onyx.Grabber", classes: "spacer", unmoveable: true},
           {name: "rightLabel", content: "_search".loc(), classes: "xv-toolbar-label"},
           // The MoreToolbar is a FittableColumnsLayout, so this spacer takes up all available space
           {name: "spacer", classes: "spacer", fit: true},

--- a/lib/enyo-x/source/views/transaction_list.js
+++ b/lib/enyo-x/source/views/transaction_list.js
@@ -16,6 +16,8 @@ trailing:true, white:true, strict:false*/
     /** @lends XV.TransactionList */{
     name: "XV.TransactionList",
     kind: "XV.List",
+    fixedHeight: true,
+    draggable: true,
     published: {
       transModule: null,
       transWorkspace: null,

--- a/lib/enyo-x/source/views/transaction_list_container.js
+++ b/lib/enyo-x/source/views/transaction_list_container.js
@@ -16,6 +16,8 @@ trailing:true, white:true, strict:false*/
     name: "XV.TransactionListContainer",
     kind: "XV.SearchPanels",
     classes: 'xv-search',
+    draggable: true,
+    realtimeFit: true,
     published: {
       prerequisite: "",
       notifyMessage: "",
@@ -38,8 +40,9 @@ trailing:true, white:true, strict:false*/
       onUpdateHeader: "updateHeader"
     },
     init: false,
+    showPullout: true,
     components: [
-      {name: "parameterPanel", kind: "FittableRows", classes: "left",
+      {name: "parameterPanel", kind: "FittableRows", classes: "xv-menu-container",
         components: [
         {kind: "onyx.Toolbar", classes: "onyx-menu-toolbar", components: [
           {kind: "font.TextIcon", name: "backButton",
@@ -57,6 +60,7 @@ trailing:true, white:true, strict:false*/
         // the onyx-menu-toolbar class keeps the popups from being hidden
         {kind: "onyx.MoreToolbar", name: "contentToolbar",
           classes: "onyx-menu-toolbar", movedClass: "xv-toolbar-moved", components: [
+          {kind: "onyx.Grabber", classes: "spacer", unmoveable: true},
           {name: "rightLabel", content: "_search".loc(), classes: "xv-toolbar-label"},
           {name: "spacer", classes: "spacer", fit: true},
           {kind: "font.TextIcon", name: "printButton", showing: false,


### PR DESCRIPTION
Adds a grabber and makes draggable both search lists and transaction lists.

**Before:**
![screen shot 2015-04-02 at 8 10 09 pm](https://cloud.githubusercontent.com/assets/1823527/6977127/4e7e282c-d974-11e4-9012-799ae3ff22a0.png)

**After:**
![screen shot 2015-04-02 at 8 08 51 pm](https://cloud.githubusercontent.com/assets/1823527/6977128/5584793c-d974-11e4-8c77-df52ee66c4b4.png)
