### PR TITLE
issue #24001: reduce seq scans, items-detail runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ script:
 
 after_failure:
   - sudo tail -n 10000 thelog.txt
-  - for LOGF in `sudo ls /var/log/postgresql` ; do echo == $LOGF ============= ; sudo tail -n 10000 $LOGF ; done
+  - for LOGF in `sudo ls /var/log/postgresql` ; do echo == $LOGF ============= ; sudo tail -n 10000 /var/log/postgresql/$LOGF ; done
   - sudo grep -r oom /var/log

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,5 @@ script:
 
 after_failure:
   - sudo tail -n 10000 thelog.txt
-  - sudo ls -l /var/log
-  - sudo ls -l /var/log/postgresql
-  - sudo tail -n 10000 /var/log/postgresql/postgresql-9.3-travis-4_8_x-dev.log
+  - for LOGF in `sudo ls /var/log/postgresql` ; do echo == $LOGF ============= ; sudo tail -n 10000 $LOGF ; done
   - sudo grep -r oom /var/log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: c
 
 install:
-  - npm install
   - wget xtuple.com/bootstrap -qO- | sudo bash
   - /usr/local/bin/npm install -g xtuple-server
+  - n 0.10.32
+  - npm install
+  - n 0.11.13
   - sudo xtuple-server install-dev --xt-demo
 
 before_script:

--- a/foundation-database/manifest.js
+++ b/foundation-database/manifest.js
@@ -20,6 +20,7 @@
     "public/indexes/apopentax.sql",
     "public/indexes/aropentax.sql",
     "public/indexes/asohisttax.sql",
+    "public/indexes/charass.sql",
     "public/indexes/cmheadtax.sql",
     "public/indexes/cmitemtax.sql",
     "public/indexes/cobilltax.sql",

--- a/foundation-database/public/indexes/charass.sql
+++ b/foundation-database/public/indexes/charass.sql
@@ -1,0 +1,1 @@
+select xt.add_index('charass', 'charass', 'charass_char_id, charass_target_type', 'btree', 'public');

--- a/foundation-database/public/indexes/charass.sql
+++ b/foundation-database/public/indexes/charass.sql
@@ -1,1 +1,1 @@
-select xt.add_index('charass', 'charass', 'charass_char_id, charass_target_type', 'btree', 'public');
+select xt.add_index('charass', 'charass_char_id, charass_target_type', 'charass_char_id_target_type_idx', 'btree', 'public');


### PR DESCRIPTION
reduce seq scans, items-detail runtime in a real customer db from 884ms to 444ms