### PR TITLE
handle duplicate items

### DIFF
--- a/lib/enyo-x/source/views/transaction_list.js
+++ b/lib/enyo-x/source/views/transaction_list.js
@@ -119,7 +119,7 @@ trailing:true, white:true, strict:false*/
           Or we have a matched itemScan and more than 1 matching models, if this is the case,
           sort the models by date and select the first one that has qty required (balance).
         */
-        (matchingModels.length && match === "itemScan")) ) {
+        (matchingModels.length && match === "itemScan"))) {
         if (matchingModels.length > 1 && match === "itemScan") {
           var sortedMatchingModels = _.sortBy(matchingModels, function (mod) {
             return mod.getValue("dueDate") || mod.getValue("scheduleDate");

--- a/lib/enyo-x/source/views/transaction_list.js
+++ b/lib/enyo-x/source/views/transaction_list.js
@@ -113,7 +113,23 @@ trailing:true, white:true, strict:false*/
             }
           }
         });
-      if (matchingModels.length === 1 && match && scan) {
+      // We have a successful scan, a matched scan attribute and a matching model
+      if (scan && ((matchingModels.length === 1 && match) ||
+        /** 
+          Or we have a matched itemScan and more than 1 matching models, if this is the case,
+          sort the models by date and select the first one that has qty required (balance).
+        */
+        (matchingModels.length && match === "itemScan")) ) {
+        if (matchingModels.length > 1 && match === "itemScan") {
+          var sortedMatchingModels = _.sortBy(matchingModels, function (mod) {
+            return mod.getValue("dueDate") || mod.getValue("scheduleDate");
+          });
+          matchingModels = [_.find(sortedMatchingModels, function (itemModel) {
+            return itemModel.getValue("balance");
+          })];
+          if (!matchingModels) {return; }
+        }
+
         var model = matchingModels[0],
           index = that.value.indexOf(model),
           scannedItems = that.getScannedItems();
@@ -130,7 +146,9 @@ trailing:true, white:true, strict:false*/
 
         // Check model for all requiredScans, if so, proceed
         if (model.validateScanAttrs()) {
-          var options = {},
+          var balance = model.getValue("balance"),
+            qtyToTransact = balance < 1 ? balance : 1,
+            options = {},
             dispOptions = {};
           if (transFunction === "receipt") {
             options.freight = model.get("freight");
@@ -139,7 +157,7 @@ trailing:true, white:true, strict:false*/
           options.detail = model.formatDetail();
           params = {
             orderLine: model.id,
-            quantity: 1, //always 1!
+            quantity: qtyToTransact,
             options: options
           };
           data.push(params);
@@ -164,12 +182,13 @@ trailing:true, white:true, strict:false*/
         }
       } else if (matchingModels.length > 1) {
         var oldMatchingModels = _.difference(this.scannedItems, matchingModels);
-
+        // Reset the old scanned models that are no longer matching.
         if (oldMatchingModels) {
           _.each(oldMatchingModels, function (model) {
             model.resetScanAttrs();
           });
         }
+        // Reset/Set the new matching models
         that.setScannedItems([]);
         _.each(matchingModels, function (model) {
           if (!_.contains(that.getScannedItems(), model)) {


### PR DESCRIPTION
There was an issue where, if a sales order has multiple line items of the same item number, the scanning would never reduce the list to a single line/issue the qty. This corrects that scenario and also handles remaining <1 balance qty.