### PR TITLE
Issue #25729: Various UOM handling improvements and consistency

### DIFF
--- a/foundation-database/manifest.js
+++ b/foundation-database/manifest.js
@@ -1044,6 +1044,7 @@
     "public/tables/checkhead.sql",
     "public/tables/company.sql",
     "public/tables/itemsite.sql",
+    "public/tables/itemuomconv.sql",
     "public/tables/location.sql",
     "public/tables/metric.sql",
     "public/tables/payco.sql",

--- a/foundation-database/public/tables/itemuomconv.sql
+++ b/foundation-database/public/tables/itemuomconv.sql
@@ -1,0 +1,1 @@
+SELECT xt.add_column('itemuomconv', 'itemuomconv_active', 'BOOLEAN', 'NOT NULL DEFAULT TRUE', 'public', 'Item UOM conversion active/inactive');

--- a/foundation-database/public/tables/metasql/uoms-item.mql
+++ b/foundation-database/public/tables/metasql/uoms-item.mql
@@ -1,9 +1,22 @@
 -- Group: uoms
 -- Name: item
--- Notes: used by bomItem
--- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+-- Notes: used by item, bomItem, salesOrderItem, invoiceItem, creditMemoItem, woMaterialItem,
+--                returnAuthorizationItem, itemPricingScheduleItem
+-- Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
 
+<? if exists("uom_id") ?>
+SELECT uom_id, uom_name
+  FROM uom
+  WHERE(uom_id=<? value("uom_id") ?>)
+UNION
+<? endif ?>
+<? if exists("uom_id2") ?>
+SELECT uom_id, uom_name
+  FROM uom
+  WHERE(uom_id=<? value("uom_id2") ?>)
+UNION
+<? endif ?>
 SELECT uom_id, uom_name
   FROM item
   JOIN uom ON (item_inv_uom_id=uom_id)
@@ -18,6 +31,7 @@ SELECT uom_id, uom_name
    AND (item_id=<? value("item_id") ?>)
    AND (itemuom_itemuomconv_id=itemuomconv_id)
    AND (uomtype_id=itemuom_uomtype_id)
+   AND (itemuomconv_active)
 <? if exists("uomtype") ?>
    AND (uomtype_name=<? value("uomtype") ?>)
 <? endif ?>
@@ -31,6 +45,7 @@ SELECT uom_id, uom_name
    AND (item_id=<? value("item_id") ?>)
    AND (itemuom_itemuomconv_id=itemuomconv_id)
    AND (uomtype_id=itemuom_uomtype_id)
+   AND (itemuomconv_active)
 <? if exists("uomtype") ?>
    AND (uomtype_name=<? value("uomtype") ?>)
 <? endif ?>


### PR DESCRIPTION
Allow Item UOM conversion to be deactivated (not deleted)

Screens previously running duplicated sql now refer to metaSQL and factor in active status