### PR TITLE
re-apply activity list refresh and icon size change

### DIFF
--- a/enyo-client/application/source/views/list.js
+++ b/enyo-client/application/source/views/list.js
@@ -81,7 +81,8 @@ trailing:true, white:true, strict: false*/
     collection: "XM.ActivityListItemCollection",
     parameterWidget: "XV.ActivityListParameters",
     published: {
-      activityActions: []
+      activityActions: [],
+      alwaysRefetch: true
     },
     actions: [
       {name: "reassignUser",
@@ -104,7 +105,7 @@ trailing:true, white:true, strict: false*/
         {kind: "FittableColumns", components: [
           {kind: "XV.ListColumn", classes: "button-column", components: [
             {kind: "XV.ListAttr", components: [
-              {tag: "i", classes: "icon-edit-sign hyperlink", isKey: true}
+              {tag: "i", classes: "icon-edit-sign hyperlink icon-large", isKey: true}
             ]}
           ]},
           {kind: "XV.ListColumn", classes: "name-column", components: [
@@ -149,8 +150,6 @@ trailing:true, white:true, strict: false*/
       var callback = function (resp, optionsObj) {
         var navigator = this.$.navigator;
         if (!resp.answer) {
-          // This is required here is using a picker - enyo bug.
-          //this.$.notifyPopup.$.customComponent.$.picker.removeNodeFromDom();
           return;
         } else if (!resp.componentValue) {
           navigator.$.contentPanels.getActive().doNotify({
@@ -183,19 +182,6 @@ trailing:true, white:true, strict: false*/
           // Send to server with dispath. Need to pass options.error callback for error handling
           XM.Model.prototype.dispatch("XM.Activity", "reassignUser", params, options);
         }
-        /*
-          XXX - hack to correct the broken scroller inside the picker (popup).
-
-          Destroy the UserPicker's decorator which removes the picker from the floatingLayer.
-          A better hack would be to address the problem of the UserPicker picker component (menu)
-          rendering directly into the floating layer. Maybe something similar to this is needed:
-          https://github.com/xtuple/xtuple/blob/4_8_x/lib/enyo-x/source/widgets/menu.js#L143
-
-          More info here:
-          http://forums.enyojs.com/discussion/1069/render-appears-to-break-scrolling-in-onyx-picker
-        */
-        // This is required here is using a picker.
-        //this.$.notifyPopup.$.customComponent.$.picker.removeNodeFromDom();
       };
 
       this.doNotify({


### PR DESCRIPTION
This commit https://github.com/xtuple/xtuple/commit/b3193998fb36c0c07b3adb5aa0e1bb6d40ffdcde reversed the icon-size https://github.com/xtuple/xtuple/issues/2232 *and* activity list refresh https://github.com/xtuple/xtuple/issues/2232 fixes. This PR adds them back.