### PR TITLE
Issue #25392: Prevent unauthorised editing of Trial Balance table

### DIFF
--- a/foundation-database/manifest.js
+++ b/foundation-database/manifest.js
@@ -1022,6 +1022,7 @@
     "public/trigger_functions/taxauth.sql",
     "public/trigger_functions/terms.sql",
     "public/trigger_functions/todoitem.sql",
+    "public/trigger_functions/trialbal.sql",
     "public/trigger_functions/uomconv.sql",
     "public/trigger_functions/usrpref.sql",
     "public/trigger_functions/usrpriv.sql",

--- a/foundation-database/public/trigger_functions/trialbal.sql
+++ b/foundation-database/public/trigger_functions/trialbal.sql
@@ -1,0 +1,20 @@
+CREATE OR REPLACE FUNCTION _trialbalaltertrigger()
+  RETURNS trigger AS $$
+-- Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple. 
+-- See www.xtuple.com/CPAL for the full text of the software license.
+BEGIN
+  IF(TG_OP='DELETE') THEN
+    RAISE EXCEPTION 'You may not delete Trial Balance Transactions.';
+  END IF;
+
+  IF (SELECT period_closed FROM period WHERE period_id=NEW.trialbal_period_id) THEN
+    RAISE EXCEPTION 'You may not alter Trial Balance records in a closed Period.';
+  END IF;
+  
+  RETURN NEW;
+END;
+$$   LANGUAGE plpgsql;
+
+SELECT dropIfExists('TRIGGER', 'trialbalaltertrigger');
+CREATE TRIGGER trialbalaltertrigger BEFORE INSERT OR UPDATE OR DELETE
+  ON trialbal FOR EACH ROW EXECUTE PROCEDURE _trialbalaltertrigger();


### PR DESCRIPTION
Similar to gltrans table introduce trigger function to prevent Db editing of trialbal table.

Due to the nature of the trialbal table the only real check we can introduce is to check for editing closed periods.