### PR TITLE
Issue #25777: Unable to convert Quotes to Sales Order

### DIFF
--- a/database/source/xt/trigger_functions/sales_order_did_change.sql
+++ b/database/source/xt/trigger_functions/sales_order_did_change.sql
@@ -13,7 +13,8 @@ return (function () {
      sqlDelete = "perform deletequote($1);",
      sql,
      orm,
-     id;
+     id,
+     showQuotes;
 
    /* Handle quote disposition if this is a new sales order converted from a quote */
    if (TG_OP === 'INSERT' &&
@@ -21,7 +22,8 @@ return (function () {
        NEW.cohead_quote_number) {
     orm = data.fetchOrm("XM", "Quote");
     id = data.getId(orm, NEW.cohead_quote_number);
-    sql = data.fetchMetric('ShowQuotesAfterSO') ? sqlUpdate : sqlDelete;
+    showQuotes = plv8.execute("SELECT fetchmetricbool('ShowQuotesAfterSO') AS metric")[0].metric;
+    sql = showQuotes ? sqlUpdate : sqlDelete;
     plv8.execute(sql, [id]);
     return NEW;
    }


### PR DESCRIPTION
Looks like it was caused by the data.fetchMetric not being available in the desktop client.  Converted to a more traditional fetchmetric.