### PR TITLE
Issue #25836: Incorrect currency decimal places on Bank Rec screen

### DIFF
--- a/foundation-database/public/tables/metasql/bankrec-checks.mql
+++ b/foundation-database/public/tables/metasql/bankrec-checks.mql
@@ -1,7 +1,7 @@
 -- Group: bankrec
 -- Name: checks
 -- Notes: used by reconcileBankaccount
---        Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+--        Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple.
 --        See www.xtuple.com/CPAL for the full text of the software license.
 
 <? if exists("summary") ?>
@@ -51,9 +51,9 @@ SELECT gltrans_id AS id, 1 AS altid,
        gltrans_notes AS notes,
        (SELECT currConcat(COALESCE(checkhead_curr_id, baseCurrId()))) AS doc_curr,
        CASE WHEN (fetchMetricValue('CurrencyExchangeSense') = 1) THEN
-         ROUND(1.0 / COALESCE(bankrecitem_curr_rate, checkhead_curr_rate, currRate(bankaccnt_curr_id, gltrans_date)),5)
+         ROUND(1.0 / COALESCE(bankrecitem_curr_rate, checkhead_curr_rate, currRate(bankaccnt_curr_id, gltrans_date)),6)
             ELSE
-         ROUND(COALESCE(bankrecitem_curr_rate, checkhead_curr_rate, currRate(bankaccnt_curr_id, gltrans_date)),5)
+         ROUND(COALESCE(bankrecitem_curr_rate, checkhead_curr_rate, currRate(bankaccnt_curr_id, gltrans_date)),6)
        END AS doc_exchrate,
        gltrans_amount AS base_amount,
        CASE WHEN (bankaccnt_curr_id=checkhead_curr_id) THEN
@@ -98,9 +98,9 @@ SELECT sltrans_id AS id, 2 AS altid,
        sltrans_notes AS notes,
        (SELECT currConcat(COALESCE(checkhead_curr_id, baseCurrId()))) AS doc_curr,
        CASE WHEN (fetchMetricValue('CurrencyExchangeSense') = 1) THEN
-         ROUND(1.0 / COALESCE(bankrecitem_curr_rate, checkhead_curr_rate, currRate(bankaccnt_curr_id, sltrans_date)),5)
+         ROUND(1.0 / COALESCE(bankrecitem_curr_rate, checkhead_curr_rate, currRate(bankaccnt_curr_id, sltrans_date)),6)
             ELSE
-         ROUND(COALESCE(bankrecitem_curr_rate, checkhead_curr_rate, currRate(bankaccnt_curr_id, sltrans_date)),5)
+         ROUND(COALESCE(bankrecitem_curr_rate, checkhead_curr_rate, currRate(bankaccnt_curr_id, sltrans_date)),6)
        END AS doc_exchrate,
        sltrans_amount AS base_amount,
        CASE WHEN (bankaccnt_curr_id=checkhead_curr_id) THEN

--- a/foundation-database/public/tables/metasql/bankrec-receipts.mql
+++ b/foundation-database/public/tables/metasql/bankrec-receipts.mql
@@ -53,9 +53,9 @@ SELECT gltrans_id AS id, 1 AS altid,
        gltrans_notes AS notes,
        currConcat(COALESCE(cashrcpt_curr_id, baseCurrId())) AS doc_curr,
        CASE WHEN (fetchMetricValue('CurrencyExchangeSense') = 1) THEN
-         ROUND(1.0 / COALESCE(bankrecitem_curr_rate, cashrcpt_curr_rate, currRate(bankaccnt_curr_id, gltrans_date)),5)
+         ROUND(1.0 / COALESCE(bankrecitem_curr_rate, cashrcpt_curr_rate, currRate(bankaccnt_curr_id, gltrans_date)),6)
             ELSE
-         ROUND(COALESCE(bankrecitem_curr_rate, cashrcpt_curr_rate, currRate(bankaccnt_curr_id, gltrans_date)),5)
+         ROUND(COALESCE(bankrecitem_curr_rate, cashrcpt_curr_rate, currRate(bankaccnt_curr_id, gltrans_date)),6)
        END AS doc_exchrate,
        (gltrans_amount * -1.0) AS base_amount,
        CASE WHEN (bankaccnt_curr_id=cashrcpt_curr_id) THEN
@@ -107,9 +107,9 @@ SELECT sltrans_id AS id, 2 AS altid,
        sltrans_notes AS notes,
        currConcat(COALESCE(cashrcpt_curr_id, baseCurrId())) AS doc_curr,
        CASE WHEN (fetchMetricValue('CurrencyExchangeSense') = 1) THEN
-         ROUND(1.0 / COALESCE(bankrecitem_curr_rate, cashrcpt_curr_rate, currRate(bankaccnt_curr_id, sltrans_date)),5)
+         ROUND(1.0 / COALESCE(bankrecitem_curr_rate, cashrcpt_curr_rate, currRate(bankaccnt_curr_id, sltrans_date)),6)
             ELSE
-         ROUND(COALESCE(bankrecitem_curr_rate, cashrcpt_curr_rate, currRate(bankaccnt_curr_id, sltrans_date)),5)
+         ROUND(COALESCE(bankrecitem_curr_rate, cashrcpt_curr_rate, currRate(bankaccnt_curr_id, sltrans_date)),6)
        END AS doc_exchrate,
        (sltrans_amount * -1.0) AS base_amount,
        CASE WHEN (bankaccnt_curr_id=cashrcpt_curr_id) THEN


### PR DESCRIPTION
5 decimal places is insufficient when converting currency so switched to 6.  This was causing rounding issues for alternate currency bank accounts.

The reconcileBankAccount code formats the currency using the UOMRatio which is manually set in the Locale screen.  I am not sure this is a good idea as this ratio defaults to 5, and the user could manually set it much lower.  I think we either introduce a new decimal setup in the Locale screen or just code it differently in the Bank Rec screen.  @gilmoskowitz appreciate your thoughts here.