### PR TITLE
Issue #25836: Insufficient decimal places in Bank Rec screen

### DIFF
--- a/foundation-database/public/tables/metasql/bankrec-checks.mql
+++ b/foundation-database/public/tables/metasql/bankrec-checks.mql
@@ -65,7 +65,7 @@ SELECT gltrans_id AS id, 1 AS altid,
                    currToLocal(bankaccnt_curr_id, gltrans_amount, gltrans_date) )
        END AS amount,
        gltrans_date AS sortdate,
-       'uomratio' AS doc_exchrate_xtnumericrole,
+       '6' AS doc_exchrate_xtnumericrole,
        'curr' AS base_amount_xtnumericrole,
        'curr' AS amount_xtnumericrole
   FROM (bankaccnt CROSS JOIN gltrans)
@@ -112,7 +112,7 @@ SELECT sltrans_id AS id, 2 AS altid,
                    currToLocal(bankaccnt_curr_id, sltrans_amount, sltrans_date) )
        END AS amount,
        sltrans_date AS sortdate,
-       'uomratio' AS doc_exchrate_xtnumericrole,
+       '6' AS doc_exchrate_xtnumericrole,
        'curr' AS base_amount_xtnumericrole,
        'curr' AS amount_xtnumericrole
   FROM (bankaccnt CROSS JOIN sltrans)
@@ -146,7 +146,7 @@ SELECT bankadj_id AS id, 3 AS altid,
        CASE WHEN(bankadjtype_iscredit=false) THEN (bankadj_amount * -1.0) ELSE bankadj_amount END AS base_amount,
        CASE WHEN(bankadjtype_iscredit=false) THEN (bankadj_amount * -1.0) ELSE bankadj_amount END AS amount,
        bankadj_date AS sortdate,
-       'uomratio' AS doc_exchrate_xtnumericrole,
+       '6' AS doc_exchrate_xtnumericrole,
        'curr' AS base_amount_xtnumericrole,
        'curr' AS amount_xtnumericrole
   FROM (bankadjtype CROSS JOIN bankadj)


### PR DESCRIPTION
Remove reference to uomratio and set exchange rate to 6 decimal places to ensure sufficient decimal places in the Bank Reconciliation screen and to ensure consistency between the metaSQL and the application.