### PR TITLE
Issue #19160: Edit Inventory Transaction causes probs for frozen sites

### DIFF
--- a/foundation-database/public/trigger_functions/invhist.sql
+++ b/foundation-database/public/trigger_functions/invhist.sql
@@ -10,10 +10,14 @@ BEGIN
 --    RAISE EXCEPTION 'Invhist (%) is recording with average costing and is not allowed to have a negative quantity on hand.', NEW.invhist_id;
 --  END IF;
 
-  IF ( ( SELECT itemsite_freeze
+-- #19160 Exclude frozen check when "Edit Transaction" ABC analyze flag is amended
+  IF ( (TG_OP = 'INSERT')
+       OR (TG_OP = 'UPDATE' AND OLD.invhist_analyze = NEW.invhist_analyze)) THEN
+    IF ( ( SELECT itemsite_freeze
          FROM itemsite
          WHERE (itemsite_id=NEW.invhist_itemsite_id) ) ) THEN
-    NEW.invhist_posted = FALSE;
+      NEW.invhist_posted = FALSE;
+    END IF;
   END IF;
 
   -- never change the created timestamp, which defaults to CURRENT_TIMESTAMP


### PR DESCRIPTION
Prevent triggering unposted inventory transactions on historical documents from the inventory transaction information screen.

Consider related qt-client PR