### PR TITLE
Limit psql error barfing to the last 20 lines on build_app.js

### DIFF
--- a/scripts/lib/util/send_to_database.js
+++ b/scripts/lib/util/send_to_database.js
@@ -29,7 +29,7 @@ regexp:true, undef:true, strict:true, trailing:true, white:true */
         ' -h ' + credsClone.hostname +
         ' -p ' + credsClone.port +
         ' -f ' + filename +
-        ' --single-transaction';
+        ' --single-transaction 2> ' + filename + '.log';
 
       /**
        * http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback
@@ -39,7 +39,17 @@ regexp:true, undef:true, strict:true, trailing:true, white:true */
       exec(psqlCommand, {maxBuffer: 40000 * 1024 /* 200x default */}, function (err, stdout, stderr) {
         if (err) {
           winston.error("Cannot install file ", filename);
-          callback(err);
+          winston.error("See errors in ", filename + ".log");
+          exec('tail -20 ' + filename + ".log", function (logerr, logstdout, logstderr) {
+            var logHeader = "\n################################################################################\n" +
+                            "# ERROR: psql stderr OUTPUT LAST 20 LINES OF: " + filename + ".log\n" +
+                            "################################################################################\n\n",
+                logfooter = "\n################################################################################\n" +
+                            "# END OF psql stderr LOG OUTPUT ################################################\n" +
+                            "################################################################################\n\n";
+            console.log(logHeader, logstdout, logfooter);
+            callback(err);
+          });
           return;
         }
         if (options.keepSql) {


### PR DESCRIPTION
Change `build_app.js` apply to database psql error output to write to a log file and console output will be:

```
./scripts/build_app.js -d test -e ../private-extensions/source/xdruple
building xdruple
info: Applying build to database test
error: Cannot install file  /home/dev/xtuple/scripts/output/build_test.sql
error: See errors in  /home/dev/xtuple/scripts/output/build_test.sql.log

################################################################################
# ERROR: psql stderr OUTPUT LAST 20 LINES OF: /home/dev/xtuple/scripts/output/build_test.sql.log
################################################################################

 psql:/home/dev/xtuple/scripts/output/build_test.sql:150: NOTICE:  function xt.iscatalogitemgrp(pg_catalog.int4) does not exist, skipping
psql:/home/dev/xtuple/scripts/output/build_test.sql:791: NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "pkgcmd_pkey" for table "pkgcmd"
psql:/home/dev/xtuple/scripts/output/build_test.sql:791: DEBUG:  building index "pkgcmd_pkey" on table "pkgcmd"
psql:/home/dev/xtuple/scripts/output/build_test.sql:804: NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "pkgimage_pkey" for table "pkgimage"
psql:/home/dev/xtuple/scripts/output/build_test.sql:804: DEBUG:  building index "pkgimage_pkey" on table "pkgimage"
psql:/home/dev/xtuple/scripts/output/build_test.sql:817: NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "pkgmetasql_pkey" for table "pkgmetasql"
psql:/home/dev/xtuple/scripts/output/build_test.sql:817: DEBUG:  building index "pkgmetasql_pkey" on table "pkgmetasql"
psql:/home/dev/xtuple/scripts/output/build_test.sql:830: NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "pkgpriv_pkey" for table "pkgpriv"
psql:/home/dev/xtuple/scripts/output/build_test.sql:830: DEBUG:  building index "pkgpriv_pkey" on table "pkgpriv"
psql:/home/dev/xtuple/scripts/output/build_test.sql:843: NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "pkgreport_pkey" for table "pkgreport"
psql:/home/dev/xtuple/scripts/output/build_test.sql:843: DEBUG:  building index "pkgreport_pkey" on table "pkgreport"
psql:/home/dev/xtuple/scripts/output/build_test.sql:856: NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "pkgscript_pkey" for table "pkgscript"
psql:/home/dev/xtuple/scripts/output/build_test.sql:856: DEBUG:  building index "pkgscript_pkey" on table "pkgscript"
psql:/home/dev/xtuple/scripts/output/build_test.sql:869: NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "pkguiform_pkey" for table "pkguiform"
psql:/home/dev/xtuple/scripts/output/build_test.sql:869: DEBUG:  building index "pkguiform_pkey" on table "pkguiform"
psql:/home/dev/xtuple/scripts/output/build_test.sql:987: NOTICE:  constraint "xd_user_contact_obj_uuid_id" of relation "xd_user_contact" does not exist, skipping
psql:/home/dev/xtuple/scripts/output/build_test.sql:988: NOTICE:  constraint "xd_user_contact_unique_uid_association" of relation "xd_user_contact" does not exist, skipping
psql:/home/dev/xtuple/scripts/output/build_test.sql:1924: ERROR:  relation "c" does not exist
LINE 1: SELECT a.b from c;
                        ^

################################################################################
# END OF psql stderr LOG OUTPUT ################################################
################################################################################


error: Command failed:  Error: Command failed:
    at ChildProcess.exithandler (child_process.js:648:15)
    at ChildProcess.emit (events.js:98:17)
    at maybeClose (child_process.js:756:16)
    at Process.ChildProcess._handle.onexit (child_process.js:823:5) killed=false, code=3, signal=null
{ [Error: Command failed: ] killed: false, code: 3, signal: null }

```

Instead of outputting the entire `build_test.sql` query to the console and therefore streaming MBs of data to remote ssh user's console which isn't helpful or fast.