### PR TITLE
Include description for toOne and toMany columns in JSON-Schema.

### DIFF
--- a/lib/orm/source/xt/javascript/schema.sql
+++ b/lib/orm/source/xt/javascript/schema.sql
@@ -425,6 +425,10 @@ select xt.install_js('XT','Schema','xtuple', $$
         if (orm.properties[i].toOne.required) {
           ret.properties[orm.properties[i].name].required = true;
         }
+
+        if (orm.properties[i].toOne.column) {
+          columns.push(orm.properties[i].toOne.column);
+        }
       }
       /* toMany property */
       else if (orm.properties[i].toMany) {
@@ -452,6 +456,10 @@ select xt.install_js('XT','Schema','xtuple', $$
             "$ref": orm.properties[i].toMany.type + "/" + relatedKey
           };
         }
+
+        if (orm.properties[i].toMany.column) {
+          columns.push(orm.properties[i].toMany.column);
+        }
       }
       /* Error */
       else {
@@ -469,15 +477,41 @@ select xt.install_js('XT','Schema','xtuple', $$
     }
 
     for (var i = 0; i < orm.properties.length; i++) {
-      /* Basic properties only. */
+      /* Basic properties. */
       if (orm.properties[i].attr && orm.properties[i].attr.column) {
         /* Loop through the returned schemaColumnInfo attributes and add them. */
         for (var attrname in schemaColumnInfo[orm.properties[i].attr.column]) {
-          if (!ret.properties[orm.properties[i].name]) {
+          if (ret.properties[orm.properties[i].name]) {
+            ret.properties[orm.properties[i].name][attrname] = schemaColumnInfo[orm.properties[i].attr.column][attrname];
+          } else {
+            var foo = true;
             /* This can happen if the same column name is errantly referenced in different properties */
-            throw new Error("Cannot get property " + orm.properties[i].name + " on ORM " + orm.nameSpace + "." + orm.type);
+            // TODO: With support for toOne and toMany column properties, this check is expected to fail on some properties.
+            // Do not throw the error. Should be removed???
+            //throw new Error("Cannot get property " + orm.properties[i].name + " on ORM " + orm.nameSpace + "." + orm.type);
           }
-          ret.properties[orm.properties[i].name][attrname] = schemaColumnInfo[orm.properties[i].attr.column][attrname];
+        }
+      }
+
+      /* toOne properties. */
+      if (orm.properties[i].toOne && orm.properties[i].toOne.column) {
+        /* Loop through the returned schemaColumnInfo attributes and add them. */
+        for (var attrname in schemaColumnInfo[orm.properties[i].toOne.column]) {
+          /* Only add column "description" as format does not apply to toOne relations. */
+          if (ret.properties[orm.properties[i].name] && attrname === "description") {
+            ret.properties[orm.properties[i].name][attrname] = schemaColumnInfo[orm.properties[i].toOne.column][attrname];
+          }
+        }
+      }
+
+      /* toMany properties. */
+      if (orm.properties[i].toMany && orm.properties[i].toMany.column) {
+        /* Loop through the returned schemaColumnInfo attributes and add them. */
+        for (var attrname in schemaColumnInfo[orm.properties[i].toMany.column]) {
+          /* Only add column "description" as format does not apply to toMany relations. */
+          if (ret.properties[orm.properties[i].name] && attrname === "description") {
+            ret.properties[orm.properties[i].name][attrname] = schemaColumnInfo[orm.properties[i].toMany.column][attrname];
+          }
         }
       }
     }
@@ -524,6 +558,10 @@ select xt.install_js('XT','Schema','xtuple', $$
       }
       /* toOne property */
       else if (orm.properties[i].toOne) {
+        if (orm.properties[i].toOne.column) {
+          columns.push(orm.properties[i].toOne.column);
+        }
+
         /* Add required override based off of ORM's property. */
         if (orm.properties[i].toOne.required) {
           ret.push(orm.properties[i].name);
@@ -531,6 +569,10 @@ select xt.install_js('XT','Schema','xtuple', $$
       }
       /* toMany property */
       else if (orm.properties[i].toMany) {
+        if (orm.properties[i].toMany.column) {
+          columns.push(orm.properties[i].toMany.column);
+        }
+
         /* Add required override based off of ORM's property. */
         if (orm.properties[i].toMany.required) {
           ret.push(orm.properties[i].name);

--- a/lib/orm/source/xt/javascript/schema.sql
+++ b/lib/orm/source/xt/javascript/schema.sql
@@ -484,7 +484,6 @@ select xt.install_js('XT','Schema','xtuple', $$
           if (ret.properties[orm.properties[i].name]) {
             ret.properties[orm.properties[i].name][attrname] = schemaColumnInfo[orm.properties[i].attr.column][attrname];
           } else {
-            var foo = true;
             /* This can happen if the same column name is errantly referenced in different properties */
             // TODO: With support for toOne and toMany column properties, this check is expected to fail on some properties.
             // Do not throw the error. Should be removed???


### PR DESCRIPTION
Our JSON-Schema includes the columns "comment" from Postgres as the description in the JSON-Schema. This worked find for basic column, but was skipped for toOne and toMany ORM relations. This PR adds support for including the description for toOne and toMany properties.

Example:
```
"XdUserContactAccount": {
      "id": "XdUserContactAccount",
      "type": "object",
      "properties": {
        "drupalUserUuid": {
          "title": "Drupal User Uuid",
          "required": true,
          "isKey": true,
          "description": "Drupal Users UUID.", <====== This was here before this PR.
          "type": "string",
          "format": "uuid"
        },
        "xdrupleSite": {
          "title": "Xdruple Site",
          "type": "String",
          "$ref": "XdSiteRelation/name",
          "required": true,
          "description": "Drupal site id for this association." <====== This was added by this PR.
        },
        "contact": {
          "title": "Contact",
          "type": "object",
          "$ref": "XdContact",
          "required": true,
          "description": "Drupal Users associated Contact." <====== This was added by this PR.
        },
        "account": {
          "title": "Account",
          "type": "object",
          "$ref": "XdAccount",
          "description": "Contacts CRM Account." <====== This was added by this PR.
        },
        "isCustomer": {
          "title": "Is Customer",
          "description": "Flag if this CRM Account is a Customer. Set to true creates new Customer if currently set to false.", <====== This was here before this PR.
          "type": "boolean"
        },
        "isProspect": {
          "title": "Is Prospect",
          "description": "Flag if this CRM Account is a Prospect. Set to true creates new Prospect if currently set to false.", <====== This was here before this PR.
          "type": "boolean"
        }
      }
    }
  },
```