### PR TITLE
req. refresh to populate FIFO data, issue all populate workspace correctly

### DIFF
--- a/lib/enyo-x/source/views/transaction_list.js
+++ b/lib/enyo-x/source/views/transaction_list.js
@@ -216,26 +216,7 @@ trailing:true, white:true, strict:false*/
     */
     fetched: function (collection, data, options) {
       this.inherited(arguments);
-
-      var that = this,
-        controlledModels = _.filter(collection.models, function (mod) {
-          return mod.requiresDetail();
-        }),
-        refreshLine = function (line, done) {
-          var modelRefreshed = function (resp) {
-            done(null, {
-              model: line
-            });
-          };
-          that.refreshModel(line.id, modelRefreshed);
-        },
-        finish = function (err, results) {
-          if (results) {
-            that.sortList();
-          }
-        };
-
-      async.mapSeries(controlledModels, refreshLine, finish);
+      this.sortList();
     },
     formatQuantity: function (value) {
       var scale = XT.locale.quantityScale;
@@ -435,10 +416,7 @@ trailing:true, white:true, strict:false*/
                 workspace: transWorkspace,
                 id: model.id,
                 callback: callback,
-                allowNew: false,
-                success: function (model) {
-                  model.transactionDate = transDate;
-                }
+                allowNew: false
               });
 
             // Otherwise just use the data we have


### PR DESCRIPTION
On `wsgbergin` pilot db:
1. Issue to Shipping lists were taking a long time to render for orders with dozens of line items due to this refreshing of every controlled item's model: https://github.com/xtuple/xtuple/compare/xtuple:4_9_x...jcarlin:4_9_preRC_bugs?expand=1#diff-827dc86936eb428bbb05e388a0e57092L220. It turns out this was occurring at the same time that the model was still in the process of setting the `FIFO` data: https://github.com/xtuple/private-extensions/blob/4_9_x/source/inventory/client/models/transaction.js#L247
2. Issue All on a Sales Order with controlled items was not populating the Issue Stock workspace. Removing this unnecessary setting of model.transactionDate https://github.com/xtuple/xtuple/compare/xtuple:4_9_x...jcarlin:4_9_preRC_bugs?expand=1#diff-827dc86936eb428bbb05e388a0e57092L439 seems to have corrected this issue in my brief testing. 
