### PR TITLE
25908 - workflow generation for PO failing

### DIFF
--- a/database/source/xt/trigger_functions/createwf_after_insert.sql
+++ b/database/source/xt/trigger_functions/createwf_after_insert.sql
@@ -38,7 +38,7 @@ return (function () {
           "from xt.poheadext join pohead on poheadext_id = pohead_id where poheadext_id = $1";
         parent = plv8.execute(parentIdSql, [NEW.poheadext_id])[0];
 
-        if (!sourceModel || !parentId) {
+        if (!sourceModel || !parent) {
           plv8.elog(WARNING, "Missing sourceModel and/or parentId needed to generate workflow!");
         }
         plv8.execute("SELECT xt.workflow_inheritsource($1, $2, $3, $4)",

--- a/enyo-client/extensions/source/project/database/source/xt/tables/wftype.sql
+++ b/enyo-client/extensions/source/project/database/source/xt/tables/wftype.sql
@@ -1,4 +1,4 @@
+DELETE FROM xt.wftype WHERE wftype_tblname = 'prjwf';
 
-insert into xt.wftype (wftype_tblname, wftype_code, wftype_src_tblname) 
-select 'prjwf', 'PRJ', 'prjtypewf'
-where not exists (select * from xt.wftype where wftype_tblname = 'prjwf');
+INSERT INTO xt.wftype (wftype_tblname, wftype_code, wftype_src_tblname) 
+VALUES ('prjwf', 'PRJ', 'prjtypewf');

--- a/enyo-client/extensions/source/purchasing/database/source/xt/tables/wftype.sql
+++ b/enyo-client/extensions/source/purchasing/database/source/xt/tables/wftype.sql
@@ -1,4 +1,4 @@
+DELETE FROM xt.wftype WHERE wftype_tblname = 'powf';
 
-insert into xt.wftype (wftype_tblname, wftype_code, wftype_src_tblname) 
-select 'powf', 'PO', 'potypewf'
-where not exists (select * from xt.wftype where wftype_tblname = 'powf');
+INSERT INTO xt.wftype (wftype_tblname, wftype_code, wftype_src_tblname) 
+VALUES ('powf', 'PO', 'potypewf');

--- a/enyo-client/extensions/source/sales/database/source/xt/tables/wftype.sql
+++ b/enyo-client/extensions/source/sales/database/source/xt/tables/wftype.sql
@@ -1,4 +1,4 @@
+DELETE FROM xt.wftype WHERE wftype_tblname = 'sowf';
 
-insert into xt.wftype (wftype_tblname, wftype_code, wftype_src_tblname) 
-select 'sowf', 'SO', 'saletypewf'
-where not exists (select * from xt.wftype where wftype_tblname = 'sowf');
+INSERT INTO xt.wftype (wftype_tblname, wftype_code, wftype_src_tblname) 
+VALUES ('sowf', 'SO', 'saletypewf');


### PR DESCRIPTION
On existing databases, the `wftype_src_tblname` was not getting populated, causing the db trigger workflow generation to fail.

Note:
- There is another bug (#25924) that will cause an error in the client if the respective `DefaultPrintPOOnSave`, `DefaultPrintSOOnSave` metric is enabled.
- The `TriggerWorkflow` metric must be enabled in order to turn on the workflow trigger functionality