### PR TITLE
Transaction List Container goes to content panel on small devices

### DIFF
--- a/lib/enyo-x/source/views/module_container.js
+++ b/lib/enyo-x/source/views/module_container.js
@@ -102,6 +102,9 @@ trailing:true, white:true*/
       }
       this.setIndex(this.getPanels().length - 1);
 
+      if (inEvent.callback) {
+        inEvent.callback(true);
+      }
       return true;
     },
     /**

--- a/lib/enyo-x/source/views/module_container.js
+++ b/lib/enyo-x/source/views/module_container.js
@@ -102,9 +102,6 @@ trailing:true, white:true*/
       }
       this.setIndex(this.getPanels().length - 1);
 
-      if (inEvent.callback) {
-        inEvent.callback(true);
-      }
       return true;
     },
     /**

--- a/lib/enyo-x/source/views/transaction_list_container.js
+++ b/lib/enyo-x/source/views/transaction_list_container.js
@@ -62,6 +62,8 @@ trailing:true, white:true, strict:false*/
           {kind: "onyx.Grabber", classes: "spacer", unmoveable: true},
           {name: "rightLabel", content: "_search".loc(), classes: "xv-toolbar-label"},
           {name: "spacer", classes: "spacer", fit: true},
+          {kind: "font.TextIcon", name: "backPanelButton", unmoveable: true,
+            content: "_back".loc(), ontap: "backPanelTapped", icon: "chevron-left"},
           {kind: "font.TextIcon", name: "printButton", showing: false,
             content: "_print".loc(), ontap: "print", icon: "print"},
           {kind: "font.TextIcon", name: "refreshButton",
@@ -89,6 +91,10 @@ trailing:true, white:true, strict:false*/
       var action = inEvent.originator.action,
         method = action.method || action.name;
       this[method](inSender, inEvent);
+    },
+    backPanelTapped: function () {
+      this.setIndex(0);
+      this.doPrevious();
     },
     close: function () {
       var callback = this.getCallback();
@@ -137,6 +143,10 @@ trailing:true, white:true, strict:false*/
       }
       this.buildMenu();
       this.$.contentToolbar.resized();
+      // If this is a mobile device, show back button, hide panel parameter widget panel.
+      if (enyo.Panels.isScreenNarrow()) {
+        this.$.backPanelButton.setShowing(true);
+      }
     },
     fetch: function (options) {
       if (!this.init) { return; }
@@ -229,6 +239,10 @@ trailing:true, white:true, strict:false*/
     selectionChanged: function () {
       this.transactionDateChanged();
       this.buildMenu();
+
+      if (enyo.Panels.isScreenNarrow() && (this.model || this.$.list.value.models.length)) {
+        this.next();
+      }
     },
     /**
       @param {Object} Options


### PR DESCRIPTION
- Transaction List Container goes to content panel on small devices
- Back button added to content panel (to transaction lists) like there is on every other list

> First panel often gets in the way of UI flow. Look into "auto collapse" as a patch for this bad mobile UI design. 