### PR TITLE
new (small device) back button to call auto-refetch on activity list

### DIFF
--- a/lib/enyo-x/source/views/transaction_list_container.js
+++ b/lib/enyo-x/source/views/transaction_list_container.js
@@ -94,7 +94,7 @@ trailing:true, white:true, strict:false*/
     },
     backPanelTapped: function () {
       this.setIndex(0);
-      this.doPrevious();
+      this.close();
     },
     close: function () {
       var callback = this.getCallback();


### PR DESCRIPTION
This https://github.com/xtuple/xtuple/pull/2359 added a new back button for small devices, in the same way that the rest of the app does, and in the new handling of the back button it wasn't missing the flag to tell the activity list to refetch.