### PR TITLE
dont create wf in mwc when triggerworkflow metric enabled

### DIFF
--- a/database/source/xm/javascript/system.sql
+++ b/database/source/xm/javascript/system.sql
@@ -12,7 +12,8 @@ select xt.install_js('XM','System','xtuple', $$
     "DashboardLite",
     "DefaultPriority",
     "RequireProjectAssignment",
-    "UseProjects"
+    "UseProjects",
+    "TriggerWorkflow"
   ],
     i, option;
 

--- a/enyo-client/application/source/en/strings.js
+++ b/enyo-client/application/source/en/strings.js
@@ -724,6 +724,7 @@
     "_transactionType": "Transaction Type",
     "_transactionSuccessful": "Transaction Successful",
     "_trigger": "Trigger",
+    "_triggerWorkflow": "Create Default Workflows through Database Trigger",
     "_type": "Type",
     "_typePattern": "Type Pattern",
     "_unit": "Unit",

--- a/enyo-client/application/source/models/sales_order.js
+++ b/enyo-client/application/source/models/sales_order.js
@@ -129,8 +129,10 @@ white:true*/
         currentHoldType = this.get("holdType"),
         defaultHoldType = this.getValue("saleType.defaultHoldType") || null;
 
-      this.inheritWorkflowSource(this.get("saleType"), "XM.SalesOrderCharacteristic",
-        "XM.SalesOrderWorkflow");
+      if (!XT.session.settings.get("TriggerWorkflow")) {
+        this.inheritWorkflowSource(this.get("saleType"), "XM.SalesOrderCharacteristic",
+          "XM.SalesOrderWorkflow");
+      }
 
       if (this.getStatus() === XM.Model.EMPTY) {
         // on a new order, set the hold type to the sale type default

--- a/enyo-client/application/source/views/workspace.js
+++ b/enyo-client/application/source/views/workspace.js
@@ -501,6 +501,8 @@ strict: false*/
           {kind: "onyx.GroupboxHeader", content: "_default".loc()},
           {kind: "XV.PriorityPicker", attr: "DefaultPriority",
             label: "_priority".loc()},
+          {kind: "onyx.GroupboxHeader", content: "_workflow".loc()},
+          {kind: "XV.CheckboxWidget", attr: "TriggerWorkflow", label: "_triggerWorkflow".loc()},
           {kind: "onyx.GroupboxHeader", content: "_creditCard".loc()},
           {kind: "XV.ScrollableGroupbox", name: "mainGroup", classes: "in-panel", components: [
             {kind: "XV.CreditCardGatewayCombobox", attr: "CCCompany",

--- a/enyo-client/extensions/source/project/client/models/project.js
+++ b/enyo-client/extensions/source/project/client/models/project.js
@@ -155,8 +155,10 @@ white:true*/
       },
 
       projectTypeDidChange: function () {
-        this.inheritWorkflowSource(this.get("projectType"), "XM.ProjectCharacteristic",
-          "XM.ProjectWorkflow");
+        if (!XT.session.settings.get("TriggerWorkflow")) {
+          this.inheritWorkflowSource(this.get("projectType"), "XM.ProjectCharacteristic",
+            "XM.ProjectWorkflow");
+        }
       },
 
       /**

--- a/enyo-client/extensions/source/purchasing/client/models/purchase_order.js
+++ b/enyo-client/extensions/source/purchasing/client/models/purchase_order.js
@@ -306,11 +306,13 @@ white:true*/
       },
 
       purchaseTypeChanged: function () {
-        this.inheritWorkflowSource(
-          this.get("purchaseType"),
-          "XM.PurchaseOrderCharacteristic",
-          "XM.PurchaseOrderWorkflow"
-        );
+        if (!XT.session.settings.get("TriggerWorkflow")) {
+          this.inheritWorkflowSource(
+            this.get("purchaseType"),
+            "XM.PurchaseOrderCharacteristic",
+            "XM.PurchaseOrderWorkflow"
+          );
+        }
       },
 
       /**


### PR DESCRIPTION
- Resolves issue #25438: add TriggerWorkflow metric to Setup > Configure > System
- Resolves issue #26001: dont create workflow in mobile if TriggerWorklow enabled

Notes:
- mobile client creates workflow items using one mechanism
- desktop client creates workflow items using a different mechanism
- if the desktop client mechanism is enabled, desktop activity generates workflow
- if the desktop client mechanism is enabled, mobile client generates workflow using _both_ mechanisms
- this PR turns off the native mobile client mechanism if the desktop mechanism is turned on so only one set of workflow data gets created

UAT:
1. Create an order that generates workflow for Sales Order, Purchase Order, Project. Verify that the workflow items are created.
2. Enable workflow through the mwc Setup > Configure > System > "Create Default Workflows through Database Trigger"
3. Repeat step 1. Verify that NO workflow items are created both before and after Save.
4. Repeat step 1 _in the qt-client_. Login to mwc, open the orders and verify that they each have workflow items.