### PR TITLE
Issue #25970: PO Line Item Freight in Alt currency

### DIFF
--- a/foundation-database/public/functions/postreceipt.sql
+++ b/foundation-database/public/functions/postreceipt.sql
@@ -1,11 +1,6 @@
--- Function: postreceipt(integer, integer)
-
--- DROP FUNCTION postreceipt(integer, integer);
-
 CREATE OR REPLACE FUNCTION postreceipt(integer, integer)
-  RETURNS integer AS
-$BODY$
--- Copyright (c) 1999-2011 by OpenMFG LLC, d/b/a xTuple. 
+  RETURNS integer AS $$
+-- Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
 DECLARE
   precvid		ALIAS FOR $1;
@@ -180,7 +175,7 @@ BEGIN
 
     UPDATE poitem
     SET poitem_qty_received = (poitem_qty_received + _r.recv_qty),
-	poitem_freight_received = (poitem_freight_received + _r.recv_freight_base)
+	poitem_freight_received = (poitem_freight_received + _r.recv_freight)
     WHERE (poitem_id=_o.orderitem_id);
 
   ELSEIF ( (_r.recv_order_type = 'RA') AND
@@ -277,7 +272,7 @@ BEGIN
 
       UPDATE poitem
       SET poitem_qty_received = (poitem_qty_received + _r.recv_qty),
-	  poitem_freight_received = (poitem_freight_received + _r.recv_freight_base)
+	  poitem_freight_received = (poitem_freight_received + _r.recv_freight)
       WHERE (poitem_id=_o.orderitem_id);
 
     ELSIF (_r.recv_order_type = 'RA') THEN
@@ -598,8 +593,6 @@ BEGIN
   RETURN _itemlocSeries;
 
 END;
-$BODY$
-  LANGUAGE plpgsql VOLATILE
-  COST 100;
-ALTER FUNCTION postreceipt(integer, integer)
-  OWNER TO admin;
+$$ LANGUAGE 'plpgsql';
+
+ALTER FUNCTION postreceipt(integer, integer) OWNER TO admin;

--- a/foundation-database/public/functions/postvoucher.sql
+++ b/foundation-database/public/functions/postvoucher.sql
@@ -303,7 +303,7 @@ BEGIN
 
 --  Attribute the correct portion to currency gain/loss
     _exchGainFreight := 0;
-    SELECT currGain(_p.pohead_curr_id, _g.vouchered_freight_base,
+    SELECT currGain(_p.pohead_curr_id, _g.vouchered_freight,
 		    _firstExchDateFreight, _p.vohead_distdate )
 		    INTO _exchGainFreight;
     IF (round(_exchGainFreight, 2) <> 0) THEN

--- a/foundation-database/public/functions/postvoucher.sql
+++ b/foundation-database/public/functions/postvoucher.sql
@@ -12,7 +12,7 @@ $$ LANGUAGE 'plpgsql';
 
 
 CREATE OR REPLACE FUNCTION postVoucher(INTEGER, INTEGER, BOOLEAN) RETURNS INTEGER AS $$
--- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple. 
+-- Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple. 
 -- See www.xtuple.com/CPAL for the full text of the software license.
 DECLARE
   pVoheadid ALIAS FOR $1;
@@ -207,10 +207,11 @@ BEGIN
                            AS value_base,
 			   (poitem_freight_received - poitem_freight_vouchered) /
 			       (poitem_qty_received - poitem_qty_vouchered) * voitem_qty AS vouchered_freight,
-                            currToBase(_p.pohead_curr_id,
-				       (poitem_freight_received - poitem_freight_vouchered) /
-				       (poitem_qty_received - poitem_qty_vouchered) * voitem_qty,
-				        _firstExchDateFreight ) AS vouchered_freight_base,
+			    -- #25970 The freight on the poitem is already in base curr    
+                            --currToBase(_p.pohead_curr_id,
+			    --	       (poitem_freight_received - poitem_freight_vouchered) /
+		            --       (poitem_qty_received - poitem_qty_vouchered) * voitem_qty,
+			    --	        _firstExchDateFreight ) AS vouchered_freight_base,
 			    voitem_freight,
 			    currToBase(_p.vohead_curr_id, voitem_freight,
                                        _p.vohead_distdate) AS voitem_freight_base
@@ -297,7 +298,7 @@ BEGIN
 --  Distribute from the clearing account
     PERFORM insertIntoGLSeries( _sequence, 'A/P', 'VO', text(_p.vohead_number),
 		_a.lb_accnt_id,
-		round(_g.value_base + _g.vouchered_freight_base, 2) * -1,
+		round(_g.value_base + _g.vouchered_freight, 2) * -1,
 		_glDate, _p.glnotes );
 
 
@@ -323,8 +324,8 @@ BEGIN
     END IF;
 
 --  Distribute the remaining freight variance to the Purchase Price Variance account
-    IF (round(_g.voitem_freight_base + _exchGainFreight, 2) <> round(_g.vouchered_freight_base, 2)) THEN
-      _tmpTotal := round(_g.voitem_freight_base + _exchGainFreight, 2) - round(_g.vouchered_freight_base, 2);
+    IF (round(_g.voitem_freight_base + _exchGainFreight, 2) <> round(_g.vouchered_freight, 2)) THEN
+      _tmpTotal := round(_g.voitem_freight_base + _exchGainFreight, 2) - round(_g.vouchered_freight, 2);
       PERFORM insertIntoGLSeries( _sequence, 'A/P', 'VO', text(_p.vohead_number),
         _a.freight_accnt_id,
 	      _tmpTotal * -1,


### PR DESCRIPTION
PO Item freight was already stored in base curr.  The Post Voucher function was incorrectly converting the freight causing G/L posting errors with incorrect PO Liability entries and Incorrect freigght gain/loss entries.