### PR TITLE
26025 disable multiSelect on small device

### DIFF
--- a/lib/enyo-x/source/views/list_base.js
+++ b/lib/enyo-x/source/views/list_base.js
@@ -118,6 +118,15 @@ trailing:true, white:true, strict:false*/
         this.refreshModel(inEvent.id, inEvent.done);
       }
     },
+    /**
+      Override, check for small display if so always disable multiSelect,
+      regardless of the kind's published value.
+    */
+    multiSelectChanged: function () {
+      var smallDisp = enyo.Panels.isScreenNarrow();
+      this.$.generator.setMultiSelect(this.multiSelect && !smallDisp);
+    },
+
     refetchList: function (inSender, inEvent) {
       // ex. XV.ActivityList re: https://github.com/xtuple/xtuple/issues/2207
       if (this.alwaysRefetch) {


### PR DESCRIPTION
UAT:
Shrink your web browser screen and reload app. Multi-select should be disabled across the app including the transaction lists (issue to shipping, enter receipt, etc).