### PR TITLE
Issue #25898: SQL Error on PO Quick Entry where no Item Source exists

### DIFF
--- a/foundation-database/public/functions/itemsrcprice.sql
+++ b/foundation-database/public/functions/itemsrcprice.sql
@@ -31,6 +31,12 @@ DECLARE
   _effective DATE;
 
 BEGIN
+
+-- Sometimes NULL itemsrc is passed (#25898)
+  IF (pItemsrcid IS NULL) THEN 
+    RETURN NULL;
+  END IF; 
+
 -- If no pEffective passed, use current date
   _effective := COALESCE(pEffective, CURRENT_DATE);
 


### PR DESCRIPTION
Scenario where no item price is entered AND no Item Source exists.