### PR TITLE
Issue #26180: Correct Check Word formatting

### DIFF
--- a/foundation-database/public/functions/checkdetailformatted.sql
+++ b/foundation-database/public/functions/checkdetailformatted.sql
@@ -20,7 +20,7 @@ BEGIN
 
 -- Check header information
   SELECT checkhead_number AS checknumber,
-         INITCAP(spellAmount(checkhead_amount, curr_id)) AS checkwords,
+         spellAmount(checkhead_amount, curr_id) AS checkwords,
          formatDate(checkhead_checkdate) AS checkdate,
          formatMoney(checkhead_amount) AS checkamount,
          curr_symbol AS checkcurrsymbol,

--- a/foundation-database/public/functions/spellamount.sql
+++ b/foundation-database/public/functions/spellamount.sql
@@ -187,7 +187,8 @@ BEGIN
     _word := trim(_curr.curr_name);
   END IF;
 
-  IF _curr.curr_abbr = 'USD' OR _curr.curr_abbr = 'CAD' THEN
+  IF _curr.curr_abbr = 'USD' OR _curr.curr_abbr = 'CAD'
+     OR _curr.curr_abbr = 'NZD' OR _curr.curr_abbr = 'AUD' THEN
       IF (_cents = '1') THEN
         _fractionalPartName = ' cent';
       ELSE
@@ -197,7 +198,7 @@ BEGIN
     _fractionalPartName = ' / 100 ';
   END IF;
 
-  RETURN _words || ' ' || _word || ' and ' || _cents || _fractionalPartName;
+  RETURN INITCAP(_words) || ' ' || _word || ' and ' || _cents || _fractionalPartName;
 END;
 $$ LANGUAGE 'plpgsql' VOLATILE;
 

--- a/foundation-database/public/tables/report/APCheck.xml
+++ b/foundation-database/public/tables/report/APCheck.xml
@@ -3,6 +3,12 @@
  <title>Sample Check Format - 3 Part - MC - Remit</title>
  <name>APCheck</name>
  <description>Sample Check Format - 3 Part - MC - Uses primary Vendor or address with names: REMIT, Remit, or remit if one exists.</description>
+ <grid>
+  <snap/>
+  <show/>
+  <x>0.05</x>
+  <y>0.05</y>
+ </grid>
  <size>Letter</size>
  <portrait/>
  <topmargin>0</topmargin>
@@ -15,7 +21,7 @@
 checkhead_id, checkhead_number, checkhead_for AS memo,
 formatDate(checkhead_checkdate) AS f_checkdate,
 formatMoney(checkhead_amount) AS f_amount,
-INITCAP(spellAmount(checkhead_amount, curr_id)) AS f_words,
+spellAmount(checkhead_amount, curr_id) AS f_words,
 CASE WHEN(checkhead_void) THEN TEXT('V O I D')
      ELSE TEXT('')
 END AS f_void,

--- a/foundation-database/public/tables/report/CheckMultiPage.xml
+++ b/foundation-database/public/tables/report/CheckMultiPage.xml
@@ -3,6 +3,12 @@
  <title>Sample Check Format - 3 Part - MC - Remit - Multi Page</title>
  <name>CheckMultiPage</name>
  <description>Sample Check Format - 3 Part - MC - Uses primary Vendor or address with names: REMIT, Remit, or remit if one exists. Multi-Page.</description>
+ <grid>
+  <snap/>
+  <show/>
+  <x>0.05</x>
+  <y>0.05</y>
+ </grid>
  <size>Letter</size>
  <portrait/>
  <topmargin>50</topmargin>
@@ -15,7 +21,7 @@
 checkhead_id, checkhead_number, checkhead_for AS memo,
 formatDate(checkhead_checkdate) AS f_checkdate,
 formatMoney(checkhead_amount) AS f_amount,
-INITCAP(spellAmount(checkhead_amount, curr_id)) AS f_words,
+spellAmount(checkhead_amount, curr_id) AS f_words,
 CASE WHEN(checkhead_void) THEN TEXT('V O I D')
      ELSE TEXT('')
 END AS f_void,
@@ -95,7 +101,7 @@ WHERE ((checkhead_curr_id = curr_id)
   <group>
    <name>Line Detail</name>
    <column>checkdata_page</column>
-   <pagebreak when="after foot" />
+   <pagebreak when="after foot"/>
    <head>
     <height>351</height>
     <field>


### PR DESCRIPTION
Search showed spellAmount was always being used in a check scenario and always had the initcap applied so removed initcap from reports/functions and applied correct formatting inside spellAmount function.