### PR TITLE
2045 activity list model changes

### DIFF
--- a/enyo-client/application/source/views/list.js
+++ b/enyo-client/application/source/views/list.js
@@ -224,7 +224,7 @@ trailing:true, white:true, strict: false*/
     },
     itemTap: function (inSender, inEvent) {
       var that = this,
-        query = this.getQuery,
+        query = this.getQuery(),
         model = this.getModel(inEvent.index),
         key = model.get("editorKey"),
         oldId = model.id,

--- a/enyo-client/application/source/views/list.js
+++ b/enyo-client/application/source/views/list.js
@@ -81,8 +81,7 @@ trailing:true, white:true, strict: false*/
     collection: "XM.ActivityListItemCollection",
     parameterWidget: "XV.ActivityListParameters",
     published: {
-      activityActions: [],
-      alwaysRefetch: true
+      activityActions: []
     },
     actions: [
       {name: "reassignUser",

--- a/enyo-client/application/source/views/list.js
+++ b/enyo-client/application/source/views/list.js
@@ -239,9 +239,9 @@ trailing:true, white:true, strict: false*/
         if (!this.getToggleSelected() || inEvent.originator.isKey) {
           inEvent.model = model;
           // Callback called in workspace save or back button
-          inEvent.callback = function (resp) {
+          inEvent.callback = function () {
             // Now display any new wf items through fetch of wf items with same editorKey
-            var done = function (resp) {
+            var done = function () {
               query.parameters = [{
                 attribute: "editorKey",
                 operator: "=",

--- a/enyo-client/application/source/views/list.js
+++ b/enyo-client/application/source/views/list.js
@@ -224,7 +224,9 @@ trailing:true, white:true, strict: false*/
       return ("_" + value.slice(0, 1).toLowerCase() + value.slice(1)).loc();
     },
     itemTap: function (inSender, inEvent) {
-      var model = this.getModel(inEvent.index),
+      var that = this,
+        query = this.getQuery,
+        model = this.getModel(inEvent.index),
         key = model.get("editorKey"),
         oldId = model.id,
         type = model.get("activityType"),
@@ -237,6 +239,20 @@ trailing:true, white:true, strict: false*/
       if (actAction) {
         if (!this.getToggleSelected() || inEvent.originator.isKey) {
           inEvent.model = model;
+          // Callback called in workspace save or back button
+          inEvent.callback = function (resp) {
+            // Now display any new wf items through fetch of wf items with same editorKey
+            var done = function (resp) {
+              query.parameters = [{
+                attribute: "editorKey",
+                operator: "=",
+                value: key
+              }];
+              that.fetch();
+            };
+            // Refresh the workflow that was tapped, it may drop off the list if complete
+            that.refreshModel(oldId, done);
+          };
           actAction.method.call(this, inSender, inEvent);
           return true;
         }

--- a/lib/enyo-x/source/views/list_base.js
+++ b/lib/enyo-x/source/views/list_base.js
@@ -20,7 +20,6 @@ trailing:true, white:true, strict:false*/
     kind: "List",
     published: {
       actions: null,
-      alwaysRefetch: false,
       headerComponents: null
     },
     events: {
@@ -35,8 +34,7 @@ trailing:true, white:true, strict:false*/
       onListItemMenuTap: "transformListAction",
       onModelChange: "modelChanged",
       onChange: "selectionChanged",
-      onSetupItem: "setupItem",
-      onRefetchList: "refetchList"
+      onSetupItem: "setupItem"
     },
     /**
       A list item has been selected. Delegate to the method cited
@@ -125,13 +123,6 @@ trailing:true, white:true, strict:false*/
     multiSelectChanged: function () {
       var smallDisp = enyo.Panels.isScreenNarrow();
       this.$.generator.setMultiSelect(this.multiSelect && !smallDisp);
-    },
-
-    refetchList: function (inSender, inEvent) {
-      // ex. XV.ActivityList re: https://github.com/xtuple/xtuple/issues/2207
-      if (this.alwaysRefetch) {
-        this.fetch();
-      }
     },
     refreshModel: function (id, afterDone) {
       // Create your own code here appropriate to the context.

--- a/lib/enyo-x/source/views/module_container.js
+++ b/lib/enyo-x/source/views/module_container.js
@@ -455,10 +455,6 @@ trailing:true, white:true*/
       // Provide a way to let panels or their children know they have been activated
       active = this.getActive();
       active.waterfallDown("onActivatePanel", {activated: active});
-      // Refetch the previous list
-      if (inEvent && inEvent.refetch) {
-        active.waterfallDown("onRefetchList");
-      }
       last.destroy();
     },
     popupWorkspaceNotify: function (inSender, inEvent) {

--- a/lib/enyo-x/source/views/navigator.js
+++ b/lib/enyo-x/source/views/navigator.js
@@ -1023,7 +1023,7 @@ trailing:true*/
       if (panel.getFilterDescription) {
         this.setHeaderContent(panel.getFilterDescription());
       }
-      if (panel.alwaysRefetch || (panel.fetch && !this.fetched[panelIndex])) {
+      if (panel.fetch && !this.fetched[panelIndex]) {
         this.fetch();
         this.fetched[panelIndex] = true;
       }

--- a/lib/enyo-x/source/views/transaction_list_container.js
+++ b/lib/enyo-x/source/views/transaction_list_container.js
@@ -98,9 +98,7 @@ trailing:true, white:true, strict:false*/
     },
     close: function () {
       var callback = this.getCallback();
-      // TODO - replace this with missing doModelChange events during line item (i.e. IssueStock) &
-      // order posting transactions https://mobile.xtuple.com/dogfood/app#workspace/incident/25480
-      this.doPrevious({refetch: true});
+      this.doPrevious();
       if (callback) { callback(); }
     },
     buildMenu: function () {


### PR DESCRIPTION
The changes required to resolve #2045 are all in `enyo-client/application/source/views/list.js`. The remaining diffs remove a previous patch to resolve the activity list not updating.

UAT:
Modifying or completing workflow items should reflect properly in the `Activity List` - items updated, removed, added should occur without the need to refresh the list.

i.e. 
1. Create a Sales Order for a Sale Type that has 'default' workflow items (Ship, Pack) configured properly with Ship being the successor.
2. Navigate to Activity List, tap on Issue to Shipping (pack) workflow, issue all line items, navigate back to Activity List. The workflow item should be removed for Issue to Shipping (pack) and the next one (ship) added.
3. Click Ship workflow and Ship the order - the browser should navigate back to the Activity List and the Ship workflow is now removed from the list (please test this Ship Shipment - Ship carefully as it appears there is a bug where the client doesn't navigate back)