### PR TITLE
CRITIAL!!! Fix getsoscheddate() performance regression. Effects all SO lists.

### DIFF
--- a/foundation-database/public/functions/getsoscheddate.sql
+++ b/foundation-database/public/functions/getsoscheddate.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE FUNCTION getSoSchedDate(INTEGER) RETURNS DATE AS $$
--- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+-- Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
 DECLARE
   pCoheadid ALIAS FOR $1;

--- a/foundation-database/public/functions/getsoscheddate.sql
+++ b/foundation-database/public/functions/getsoscheddate.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE FUNCTION getSoSchedDate(INTEGER) RETURNS DATE AS $$
--- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple. 
+-- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
 DECLARE
   pCoheadid ALIAS FOR $1;
@@ -8,9 +8,14 @@ DECLARE
 BEGIN
 
   SELECT MIN(coitem_scheddate) INTO _minscheddate
-  FROM cohead JOIN coitem ON (coitem_cohead_id=pCoheadid)
-  WHERE CASE WHEN (cohead_status='C') THEN coitem_status != 'X'
-             ELSE coitem_status NOT IN ('C','X') END;
+  FROM cohead
+  JOIN coitem ON (coitem_cohead_id=pCoheadid)
+  WHERE true
+    AND cohead_id=pCoheadid
+    AND CASE WHEN (cohead_status='C')
+      THEN coitem_status != 'X'
+      ELSE coitem_status NOT IN ('C','X')
+    END;
 
   RETURN _minscheddate;
 


### PR DESCRIPTION
getSoSchedDate(INTEGER) was selecting ALL cohead orders to get the status of one order.