### PR TITLE
Remove qr-image. It's not used anymore.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -18,9 +18,9 @@
       "resolved": "https://registry.npmjs.org/backbone-relational/-/backbone-relational-0.8.0.tgz"
     },
     "bcrypt": {
-      "version": "0.8.4",
+      "version": "0.8.5",
       "from": "bcrypt@>=0.8.0 <0.9.0",
-      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-0.8.4.tgz",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-0.8.5.tgz",
       "dependencies": {
         "bindings": {
           "version": "1.2.1",
@@ -28,9 +28,9 @@
           "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
         },
         "nan": {
-          "version": "1.8.4",
-          "from": "nan@1.8.4",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
+          "version": "2.0.5",
+          "from": "nan@2.0.5",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.5.tgz"
         }
       }
     },
@@ -741,7 +741,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.1 <0.3.0",
+                      "from": "ansi-regex@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
@@ -753,7 +753,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.1 <0.3.0",
+                      "from": "ansi-regex@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
@@ -2520,11 +2520,6 @@
           "resolved": "https://registry.npmjs.org/deprecate/-/deprecate-0.1.0.tgz"
         }
       }
-    },
-    "qr-image": {
-      "version": "1.1.0",
-      "from": "qr-image@>=1.1.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/qr-image/-/qr-image-1.1.0.tgz"
     },
     "request": {
       "version": "2.14.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "paynode": "0.3.6",
     "pegjs": "0.8.x",
     "pg": "0.14.x",
-    "qr-image": "1.1.x",
     "request": "2.14.x",
     "rimraf": "2.2.x",
     "rjson": "~0.2.4",


### PR DESCRIPTION
`npm shrinkwrap` picked up the new version of bcrypt that came out today. That's why it's in this PR.