### PR TITLE
resolves issue #26360: workflow items created through qt client shoul…

### DIFF
--- a/database/source/xt/functions/workflow_inheritsource.sql
+++ b/database/source/xt/functions/workflow_inheritsource.sql
@@ -46,7 +46,7 @@ $BODY$
   templateSQL = "SELECT obj_uuid, wfsrc_name as name,wfsrc_description as descr,wfsrc_type as type,wfsrc_status as status, " +
     "CASE WHEN wfsrc_start_set THEN current_date + wfsrc_start_offset ELSE null END as startDate, " +
     "CASE WHEN wfsrc_due_set THEN current_date + wfsrc_due_offset ELSE null END as dueDate, " +
-    "wfsrc_notes as notes, wfsrc_priority_id as priority,wfsrc_owner_username as owner,wfsrc_assigned_username as assigned, " +
+    "wfsrc_notes as notes, wfsrc_priority_id as priority, COALESCE(wfsrc_owner_username, (SELECT current_user)) as owner, COALESCE(wfsrc_assigned_username, (SELECT current_user)) as assigned, " +
     "wfsrc_completed_parent_status as compl_status,wfsrc_deferred_parent_status as defer_status,wfsrc_sequence as sequence, " +
     "wfsrc_completed_successors as compl_successor, wfsrc_deferred_successors as defer_successor" +
     " FROM %1$I.%2$I WHERE wfsrc_parent_id = $1 ";

--- a/database/source/xt/functions/workflow_inheritsource.sql
+++ b/database/source/xt/functions/workflow_inheritsource.sql
@@ -46,7 +46,7 @@ $BODY$
   templateSQL = "SELECT obj_uuid, wfsrc_name as name,wfsrc_description as descr,wfsrc_type as type,wfsrc_status as status, " +
     "CASE WHEN wfsrc_start_set THEN current_date + wfsrc_start_offset ELSE null END as startDate, " +
     "CASE WHEN wfsrc_due_set THEN current_date + wfsrc_due_offset ELSE null END as dueDate, " +
-    "wfsrc_notes as notes, wfsrc_priority_id as priority, COALESCE(wfsrc_owner_username, (SELECT current_user)) as owner, COALESCE(wfsrc_assigned_username, (SELECT current_user)) as assigned, " +
+    "wfsrc_notes as notes, wfsrc_priority_id as priority, COALESCE(wfsrc_owner_username, current_user) as owner, COALESCE(wfsrc_assigned_username, current_user) as assigned, " +
     "wfsrc_completed_parent_status as compl_status,wfsrc_deferred_parent_status as defer_status,wfsrc_sequence as sequence, " +
     "wfsrc_completed_successors as compl_successor, wfsrc_deferred_successors as defer_successor" +
     " FROM %1$I.%2$I WHERE wfsrc_parent_id = $1 ";

--- a/lib/enyo-x/source/views/workspace.js
+++ b/lib/enyo-x/source/views/workspace.js
@@ -563,11 +563,14 @@ trailing:true, white:true, strict: false*/
           done: options.modelChangeDone
         };
       options.success = function (model, resp, options) {
-        var wfModels = model.getValue("workflow") ? model.getValue("workflow").models : null;
-        // A couple extra key-values for workflow / activity list modelChange handling
-        if (wfModels) {
-          inEvent.updateActivityList = true;
-          inEvent.uuid = that.getValue("uuid");
+        // If a workflow item is attached to this workspace include some extra attributes for doModelChange
+        if (typeof(model) === "object") { // some models don't define model in success call
+          var wfModels = model.getValue("workflow") ? model.getValue("workflow").models : null;
+          // A couple extra key-values for workflow / activity list modelChange handling
+          if (wfModels) {
+            inEvent.updateActivityList = true;
+            inEvent.uuid = that.getValue("uuid");
+          }
         }
         that.doModelChange(inEvent);
         that.parent.parent.modelSaved();


### PR DESCRIPTION
…d use current user as owner/assigned to if null in wf config

UAT:
1. Login to mwc with admin user. Setup a workflow config (i.e. sale type or purchase type). The first item in the workflow setup needs to have status as In Process.
2. Create an order in the mwc and set the correct type, check to verify that the workflow item(s) have been created in the order so that you know your config is working as designed. 
3. Navigate to the activity list to be sure the new workflows (only the in-process wf items display) are there.
3. Enable the 'TriggerWorkflow' metric - this can be done through mwc Setup > Configure > System > Create Default Workflows through database trigger
4. Create the same order in qt client logged in as admin and then navigate to mwc activity list, refresh and the wf items and order should display when filtered on admin user. The new wf items will have `admin` as owner and assigned to.