### PR TITLE
Corrects transaction list item tap failure

### DIFF
--- a/lib/enyo-x/source/views/list.js
+++ b/lib/enyo-x/source/views/list.js
@@ -89,7 +89,7 @@ trailing:true, white:true, strict:false*/
       // TODO - replace fluentReports handling with openRPT
       onPrintList: "",
       onPrintSelectList: "",
-      onProcessingChanged: ""
+      onFetchedFinished: ""
     },
     /**
      @todo Document the collectionChanged method.
@@ -447,7 +447,7 @@ trailing:true, white:true, strict:false*/
       if (count < len) { this.lazyLoad(); }
       // Turn off the spinner
       if (count === len) {
-        this.doProcessingChanged({isProcessing: false, emptyList: len > 0 ? false : true});
+        this.doFetchedFinished({isProcessing: false, emptyList: len > 0 ? false : true});
       }
     },
     /**

--- a/lib/enyo-x/source/views/navigator.js
+++ b/lib/enyo-x/source/views/navigator.js
@@ -67,7 +67,7 @@ trailing:true*/
       onPrintSelectList: "printSelectList",
       onReportList: "reportList",
       onGenerateReport: "generateReport",
-      onProcessingChanged: "processingChanged"
+      onFetchedFinished: "fetchedFinished"
     },
     showPullout: true,
     components: [
@@ -1039,7 +1039,7 @@ trailing:true*/
     /**
       Handle popup spinner
     */
-    processingChanged: function (inSender, inEvent) {
+    fetchedFinished: function (inSender, inEvent) {
       if (inEvent.isProcessing && !this.$.spinnerPopup.showing) {
         this._popupDone = false;
         this.$.spinnerPopup.show();
@@ -1103,7 +1103,7 @@ trailing:true*/
         // panel exists but has not been rendered. Render it.
         module.panels[index].status = 'active';
         // Show the spinner
-        this.processingChanged(null, {isProcessing: true});
+        this.fetchedFinished(null, {isProcessing: true});
         // Default behavior for Lists is toggle selections
         // So we can perform actions on rows. If not a List
         // this property shouldn't hurt anything

--- a/lib/enyo-x/source/views/navigator.js
+++ b/lib/enyo-x/source/views/navigator.js
@@ -1089,7 +1089,8 @@ trailing:true*/
         label,
         collection,
         model,
-        canNotCreate = true;
+        canNotCreate = true,
+        show;
 
       this.clearMessage();
       if (panelStatus === 'active') {
@@ -1097,7 +1098,8 @@ trailing:true*/
           return child.index === panelIndex;
         });
         if (panel.value) {
-          this.$.emptyListMessage.setShowing(!panel.value.length);
+          show = panel && panel.value ? !panel.value.length : false;
+          this.$.emptyListMessage.setShowing(show);
         }
       } else if (panelStatus === 'unborn') {
         // panel exists but has not been rendered. Render it.
@@ -1120,10 +1122,11 @@ trailing:true*/
       } else if (panelStatus === 'cached') {
         module.panels[index].status = 'active';
         panel = this.panelCache[panelIndex];
+        show = panel && panel.value ? !panel.value.length : false;
         contentPanels.addChild(panel);
         panel.node = undefined; // new to enyo2.2! wipe out the node so that it can get re-rendered fresh
         panel.render();
-        this.$.emptyListMessage.setShowing(!panel.value.length);
+        this.$.emptyListMessage.setShowing(show);
       } else {
         XT.error("Don't know what to do with this panel status");
       }

--- a/lib/enyo-x/source/views/transaction_list_container.js
+++ b/lib/enyo-x/source/views/transaction_list_container.js
@@ -218,6 +218,7 @@ trailing:true, white:true, strict:false*/
         this.requery();
         this.spinnerHide();
       }
+      return true;
     },
     /**
       Overload: Piggy back on existing handler for `onParameterChanged event`


### PR DESCRIPTION
Ready.

https://github.com/xtuple/xtuple/pull/2466's `onProcessingChanged` event clashed with transactionListContainer/transactionList's `onProcessingChanged` https://github.com/xtuple/xtuple/blob/4_10_x/lib/enyo-x/source/views/transaction_list.js#L33. The result was the inability to tap a line item and an endless loop of the list re-fetching. This pr changes the name of the new event to avoid this.