### PR TITLE
Issue #26421: Fix qtyNetable function which was returning NULL 

### DIFF
--- a/foundation-database/public/functions/qtynetable.sql
+++ b/foundation-database/public/functions/qtynetable.sql
@@ -38,7 +38,7 @@ BEGIN
        AND (NOT COALESCE(location_netable, true));
   END IF;
 
-  RETURN _qty;
+  RETURN COALESCE(_qty, 0.0);
 
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
Inventory solely located in a non-netable location resulted in this function returning NULL and preventing MPS schedule from working.

@garyhgohoos would you mind checking my logic please?