### PR TITLE
resolves issue #2161

### DIFF
--- a/lib/enyo-x/source/widgets/input.js
+++ b/lib/enyo-x/source/widgets/input.js
@@ -41,7 +41,24 @@ regexp:true, undef:true, trailing:true, white:true */
         {name: "label", classes: "xv-label"},
         {kind: "onyx.InputDecorator", components: [
           {name: "input", kind: "onyx.Input", onchange: "inputChanged", onkeydown: "keyDown",
-          selectOnFocus: true}
+            selectOnFocus: true,
+            /**
+              Override as a workaround for https://code.google.com/p/chromium/issues/detail?id=324360
+            */
+            selectContents: function () {
+              var n = this.hasNode();
+
+              if (!n) { return; }
+              if (n.setSelectionRange) {
+                try {
+                  n.setSelectionRange(0, n.value.length);
+                }
+                catch(err) {
+                  n.select();
+                }
+              } else { n.select(); }
+            }
+          }
         ]}
       ]}
     ],

--- a/lib/enyo-x/source/widgets/number.js
+++ b/lib/enyo-x/source/widgets/number.js
@@ -15,7 +15,7 @@ regexp:true, undef:true, trailing:true, white:true */
     name: "XV.NumberWidget",
     kind: "XV.InputWidget",
     classes: "xv-numberwidget xv-input",
-    type: "DecimalInput",
+    type: "number",
     published: {
       attr: null,
       scale: 0,


### PR DESCRIPTION
This is fixed as desired in android. However, in iOS it is the in-line number keyboard.

Changed `XV.NumberWidget`'s type to `number` and stomped on `enyo.Input`'s `selectContents` to avoid this bug https://code.google.com/p/chromium/issues/detail?id=324360.

![screen shot 2015-08-31 at 1 43 29 pm](https://cloud.githubusercontent.com/assets/1823527/9588720/feb7dfb0-4fe6-11e5-8553-c4d3dc6836c9.png)
