### PR TITLE
reassign activity item - change back to picker and correct scrolling

### DIFF
--- a/enyo-client/application/source/views/list.js
+++ b/enyo-client/application/source/views/list.js
@@ -151,6 +151,7 @@ trailing:true, white:true, strict: false*/
       var callback = function (resp, optionsObj) {
         var navigator = this.$.navigator;
         if (!resp.answer) {
+          this.$.notifyPopup.$.customComponent.$.pickerDecorator.destroyClientControls();
           return;
         } else if (!resp.componentValue) {
           navigator.$.contentPanels.getActive().doNotify({
@@ -183,6 +184,7 @@ trailing:true, white:true, strict: false*/
           // Send to server with dispath. Need to pass options.error callback for error handling
           XM.Model.prototype.dispatch("XM.Activity", "reassignUser", params, options);
         }
+        this.$.notifyPopup.$.customComponent.$.pickerDecorator.destroyClientControls();
       };
 
       this.doNotify({
@@ -191,8 +193,15 @@ trailing:true, white:true, strict: false*/
         message: "_reassignSelectedActivities".loc(),
         yesLabel: "_reassign".loc(),
         noLabel: "_cancel".loc(),
-        component: {kind: "XV.UserAccountWidget", name: "assignTo", label: "_assignTo".loc(),
-          menuDisabled: true},
+        component: {kind: "XV.UserPicker", name: "assignTo", showLabel: false,
+          filter: function (models) {
+            var activeUsers = _.filter(models, function (usr) {
+              return usr.getValue("isActive");
+            });
+
+            return activeUsers;
+          }
+        },
         options: {models: this.selectedModels()}
       });
     },

--- a/enyo-client/application/source/views/list.js
+++ b/enyo-client/application/source/views/list.js
@@ -151,7 +151,6 @@ trailing:true, white:true, strict: false*/
       var callback = function (resp, optionsObj) {
         var navigator = this.$.navigator;
         if (!resp.answer) {
-          this.$.notifyPopup.$.customComponent.$.pickerDecorator.destroyClientControls();
           return;
         } else if (!resp.componentValue) {
           navigator.$.contentPanels.getActive().doNotify({
@@ -184,7 +183,6 @@ trailing:true, white:true, strict: false*/
           // Send to server with dispath. Need to pass options.error callback for error handling
           XM.Model.prototype.dispatch("XM.Activity", "reassignUser", params, options);
         }
-        this.$.notifyPopup.$.customComponent.$.pickerDecorator.destroyClientControls();
       };
 
       this.doNotify({

--- a/enyo-client/application/source/views/list.js
+++ b/enyo-client/application/source/views/list.js
@@ -198,7 +198,7 @@ trailing:true, white:true, strict: false*/
             var activeUsers = _.filter(models, function (usr) {
               return usr.getValue("isActive");
             });
-
+            // TODO - only return "warehouse" users.
             return activeUsers;
           }
         },

--- a/lib/enyo-x/source/views/module_container.js
+++ b/lib/enyo-x/source/views/module_container.js
@@ -432,6 +432,8 @@ trailing:true, white:true*/
             return;
           }
           callbackObj.componentValue = this.$.notifyPopup.$.customComponent.getValue();
+          // This will correct picker menu issues
+          this.$.notifyPopup.$.customComponent.destroy();
         }
         this._notifyCallback(callbackObj, optionsObj);
       } else {

--- a/test/specs/activity.js
+++ b/test/specs/activity.js
@@ -60,7 +60,6 @@ before:true, exports:true, it:true, describe:true, XG:true */
       assert.isTrue(popup.showing);
       popup.$.customComponent.setValue(newAssignedTo);
       setTimeout(function () {
-        assert.equal(popup.$.customComponent.$.input.getValue(), newAssignedTo);
         moduleContainer.notifyTap(null, { originator: {name: "notifyYes"}});
         setTimeout(function () {
           assert.equal(actList.value.models[0].getValue("assignedTo.username"), newAssignedTo);

--- a/test/specs/activity.js
+++ b/test/specs/activity.js
@@ -62,12 +62,11 @@ before:true, exports:true, it:true, describe:true, XG:true */
       setTimeout(function () {
         assert.equal(popup.$.customComponent.$.input.getValue(), newAssignedTo);
         moduleContainer.notifyTap(null, { originator: {name: "notifyYes"}});
-      }, 2000);
-
-      setTimeout(function () {
-        assert.equal(actList.value.models[0].getValue("assignedTo.username"), newAssignedTo);
-        done();
-      }, 5000);
+        setTimeout(function () {
+          assert.equal(actList.value.models[0].getValue("assignedTo.username"), newAssignedTo);
+          done();
+        }, 2000);
+      }, 1000);
     });
   };
 


### PR DESCRIPTION
This bug https://www.xtuple.org/xtincident/view/bugs/24975 was previously 'resolved' by replacing the picker widget with a relational widget. This was bad design, so reverting it back to Picker while correcting the bug that was preventing proper menu display and scrolling.

UAT:
Create 4 additional users to have enough for scroll bar to display.
Activity List > gear tap Reassign User.
Should be able to scroll through the list, select a user and tap ok.
Reassign User again should properly display the list and allow for scrolling.

![screen shot 2015-09-04 at 3 10 43 pm](https://cloud.githubusercontent.com/assets/1823527/9694588/4a5517fc-5317-11e5-8b61-2ce14a40f171.png)