### PR TITLE
Remove js_init() Object freeze. It never worked anyway.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,4 @@ after_failure:
   - sudo tail -n 10000 thelog.txt
   - for LOGF in `sudo ls /var/log/postgresql` ; do echo == $LOGF ============= ; sudo tail -n 10000 /var/log/postgresql/$LOGF ; done
   - sudo grep -r oom /var/log
+  - sudo tail -n 10000 npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,3 @@ after_failure:
   - sudo tail -n 10000 thelog.txt
   - for LOGF in `sudo ls /var/log/postgresql` ; do echo == $LOGF ============= ; sudo tail -n 10000 /var/log/postgresql/$LOGF ; done
   - sudo grep -r oom /var/log
-  - sudo tail -n 10000 npm-debug.log

--- a/lib/orm/source/xt/functions/js_init.sql
+++ b/lib/orm/source/xt/functions/js_init.sql
@@ -921,14 +921,6 @@ return (function () {
         if(DEBUG) XT.debug('loading javascript for type->', res[i].js_type);
 
         eval(res[i].javascript);
-
-        var ns = eval(res[i].js_namespace);
-        if (ns && ns[js_type]) {
-          if (Object.isFrozen(ns[js_type])) {
-            plv8.elog(WARNING, 'object already frozen: '+ ns + '.' + js_type);
-          }
-          Object.freeze(ns[js_type]);
-        }
       }
     }
     plv8.__initialized = true;

--- a/scripts/install_xtuple.sh
+++ b/scripts/install_xtuple.sh
@@ -190,9 +190,9 @@ install_packages() {
   npm install --unsafe-perm 2>&1 | tee -a $LOG_FILE
   
   #if [ -f npm-debug.log ]; then
-    echo "== npm-debug.log =============" >> $LOG_FILE
-    cat npm-debug.log >> $LOG_FILE
-    echo "== END npm-debug.log =============" >> $LOG_FILE
+    echo "== npm-debug.log =============" >> thelog.txt
+    cat npm-debug.log >> thelog.txt
+    echo "== END npm-debug.log =============" >> thelog.txt
   #fi
 }
 

--- a/scripts/install_xtuple.sh
+++ b/scripts/install_xtuple.sh
@@ -188,9 +188,12 @@ install_packages() {
   log "installing npm modules..."
   sudo chown -R $USER $HOME/.npm
   npm install --unsafe-perm 2>&1 | tee -a $LOG_FILE
-  echo "== npm-debug.log =============" >> $LOG_FILE
-  cat npm-debug.log >> $LOG_FILE
-  echo "== END npm-debug.log =============" >> $LOG_FILE
+  
+  if [ -f npm-debug.log ]; then
+    echo "== npm-debug.log =============" >> $LOG_FILE
+    cat npm-debug.log >> $LOG_FILE
+    echo "== END npm-debug.log =============" >> $LOG_FILE
+  fi
 }
 
 # Use only if running from a debian package install for the first time

--- a/scripts/install_xtuple.sh
+++ b/scripts/install_xtuple.sh
@@ -189,9 +189,9 @@ install_packages() {
   sudo chown -R $USER $HOME/.npm
   npm install --unsafe-perm 2>&1 | tee -a $LOG_FILE
   
-  if [ -f npm-debug.log ]; then
+  if [ -f /home/travis/build/xtuple/xtuple/npm-debug.log ]; then
     echo "== npm-debug.log =============" >> $LOG_FILE
-    cat npm-debug.log >> $LOG_FILE
+    cat /home/travis/build/xtuple/xtuple/npm-debug.log >> $LOG_FILE
     echo "== END npm-debug.log =============" >> $LOG_FILE
   fi
 }

--- a/scripts/install_xtuple.sh
+++ b/scripts/install_xtuple.sh
@@ -170,7 +170,7 @@ install_packages() {
     # the path alias to it.
     log "npm version:"
     npm -v
-    npm install npm@latest
+    npm install npm@2.13.4
     rm -rf ~/.nvm/v${NODE_VERSION}/bin/npm
     ln -s ~/node_modules/.bin/npm ~/.nvm/v${NODE_VERSION}/bin/npm
     # Reset bash's cache.
@@ -178,7 +178,7 @@ install_packages() {
     log "npm version:"
     npm -v
   else
-    sudo npm install -fg npm@latest
+    sudo npm install -fg npm@2.13.4
   fi
 
   # npm no longer supports its self-signed certificates

--- a/scripts/install_xtuple.sh
+++ b/scripts/install_xtuple.sh
@@ -188,6 +188,9 @@ install_packages() {
   log "installing npm modules..."
   sudo chown -R $USER $HOME/.npm
   npm install --unsafe-perm 2>&1 | tee -a $LOG_FILE
+  echo "== npm-debug.log =============" >> $LOG_FILE
+  cat npm-debug.log >> $LOG_FILE
+  echo "== END npm-debug.log =============" >> $LOG_FILE
 }
 
 # Use only if running from a debian package install for the first time

--- a/scripts/install_xtuple.sh
+++ b/scripts/install_xtuple.sh
@@ -188,12 +188,6 @@ install_packages() {
   log "installing npm modules..."
   sudo chown -R $USER $HOME/.npm
   npm install --unsafe-perm 2>&1 | tee -a $LOG_FILE
-  
-  #if [ -f npm-debug.log ]; then
-    echo "== npm-debug.log =============" >> thelog.txt
-    cat npm-debug.log >> thelog.txt
-    echo "== END npm-debug.log =============" >> thelog.txt
-  #fi
 }
 
 # Use only if running from a debian package install for the first time

--- a/scripts/install_xtuple.sh
+++ b/scripts/install_xtuple.sh
@@ -189,11 +189,11 @@ install_packages() {
   sudo chown -R $USER $HOME/.npm
   npm install --unsafe-perm 2>&1 | tee -a $LOG_FILE
   
-  if [ -f /home/travis/build/xtuple/xtuple/npm-debug.log ]; then
+  #if [ -f npm-debug.log ]; then
     echo "== npm-debug.log =============" >> $LOG_FILE
-    cat /home/travis/build/xtuple/xtuple/npm-debug.log >> $LOG_FILE
+    cat npm-debug.log >> $LOG_FILE
     echo "== END npm-debug.log =============" >> $LOG_FILE
-  fi
+  #fi
 }
 
 # Use only if running from a debian package install for the first time

--- a/scripts/install_xtuple.sh
+++ b/scripts/install_xtuple.sh
@@ -170,7 +170,7 @@ install_packages() {
     # the path alias to it.
     log "npm version:"
     npm -v
-    npm install npm@2.13.4
+    npm install npm@2.x
     rm -rf ~/.nvm/v${NODE_VERSION}/bin/npm
     ln -s ~/node_modules/.bin/npm ~/.nvm/v${NODE_VERSION}/bin/npm
     # Reset bash's cache.
@@ -178,7 +178,7 @@ install_packages() {
     log "npm version:"
     npm -v
   else
-    sudo npm install -fg npm@2.13.4
+    sudo npm install -fg npm@2.x
   fi
 
   # npm no longer supports its self-signed certificates


### PR DESCRIPTION
The var `js_type` was never defined, so `if (ns && ns[js_type]) {` always evaluated to false. This code has never even been executed. 
https://github.com/xtuple/xtuple/commit/17bc91e78583745cfb223843284d4758684f12be#diff-b85848426d86622a59a82f375bbbea5fR855

I don't think we should consider freezing all Objects:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isFrozen

If an Object is frozen, an extension would not be able to alter an object to add additional methods/properties. e.g. `XM.Contact`. The `xTConnect` extension might want to add a `XM.Contact.sendEmail()` method or create additional properties: `XM.Contact.associatedEmails`. If we freeze the core `XM.Contact` Object when it's loaded into the `plv8` environment, extensions would not be able to do this.