### PR TITLE
Issue #26190: Only check Trial Balance closed periods where necessary

### DIFF
--- a/foundation-database/public/trigger_functions/trialbal.sql
+++ b/foundation-database/public/trigger_functions/trialbal.sql
@@ -2,16 +2,29 @@ CREATE OR REPLACE FUNCTION _trialbalaltertrigger()
   RETURNS trigger AS $$
 -- Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple. 
 -- See www.xtuple.com/CPAL for the full text of the software license.
+DECLARE
+  _accntid INTEGER[];
 BEGIN
   IF(TG_OP='DELETE') THEN
     RAISE EXCEPTION 'You may not delete Trial Balance Transactions.';
   END IF;
 
-  /* bug 26190 vs bug 25392 - uncomment this when the fre stops updating trial balances
-  IF (SELECT period_closed FROM period WHERE period_id=NEW.trialbal_period_id) THEN
-    RAISE EXCEPTION 'You may not alter Trial Balance records in a closed Period.';
-  END IF;
-  */
+  IF (coalesce(fetchMetricValue('GLCompanySize'),0) = 0) THEN
+  --  Retained Earnings account
+      _accntid := fetchmetricvalue('YearEndEquityAccount');
+  ELSE
+  --  Multi-company Retained Earnings setup
+      _accntid := (SELECT array_agg(company_yearend_accnt_id)
+                  FROM company);
+  END IF;    
+
+  If (NEW.trialbal_accnt_id = ANY(_accntid) OR (NEW.trialbal_beginning = 0.00 AND NEW.trialbal_ending = 0.00)) THEN 
+    --  Dont check new accounts or Retained Earnings account 
+  ELSE
+    IF (SELECT period_closed FROM period WHERE period_id=NEW.trialbal_period_id) THEN
+      RAISE EXCEPTION 'You may not alter Trial Balance records in a closed Period.';
+    END IF;
+  END IF;  
   
   RETURN NEW;
 END;

--- a/foundation-database/public/trigger_functions/trialbal.sql
+++ b/foundation-database/public/trigger_functions/trialbal.sql
@@ -5,30 +5,35 @@ CREATE OR REPLACE FUNCTION _trialbalaltertrigger()
 DECLARE
   _accntid INTEGER[];
 BEGIN
-  IF(TG_OP='DELETE') THEN
+  IF (TG_OP='DELETE') THEN
     IF (SELECT period_closed FROM period WHERE period_id=OLD.trialbal_period_id) THEN
       RAISE EXCEPTION 'You may not delete Trial Balance Transactions in closed periods.';
     END IF;
+
+    RETURN OLD;
   END IF;
 
-  IF (coalesce(fetchMetricValue('GLCompanySize'),0) = 0) THEN
-  --  Get the default account number for year end closing
+  IF (TG_OP='INSERT' OR TG_OP='UPDATE') THEN
+    IF (coalesce(fetchMetricValue('GLCompanySize'),0) = 0) THEN
+    --  Get the default account number for year end closing
       _accntid := fetchmetricvalue('YearEndEquityAccount');
-  ELSE
-  --  Multi-company setup
-      _accntid := (SELECT array_agg(company_yearend_accnt_id)
+    ELSE
+    --  Multi-company setup
+       _accntid := (SELECT array_agg(company_yearend_accnt_id)
                   FROM company);
-  END IF;    
-
-  If (NEW.trialbal_accnt_id = ANY(_accntid) OR (NEW.trialbal_beginning = 0.00 AND NEW.trialbal_ending = 0.00)) THEN 
-    --  Dont check new accounts or Retained Earnings account 
-  ELSE
-    IF (SELECT period_closed FROM period WHERE period_id=NEW.trialbal_period_id) THEN
-      RAISE EXCEPTION 'You may not alter Trial Balance records in a closed Period.';
     END IF;
-  END IF;  
+
+    If (NEW.trialbal_accnt_id = ANY(_accntid) OR (NEW.trialbal_beginning = 0.00 AND NEW.trialbal_ending = 0.00)) THEN
+    --  Dont check new accounts or Retained Earnings account 
+    ELSE
+      IF (SELECT period_closed FROM period WHERE period_id=NEW.trialbal_period_id) THEN
+        RAISE EXCEPTION 'You may not alter Trial Balance records in a closed Period.';
+      END IF;
+    END IF;
   
-  RETURN NEW;
+    RETURN NEW;
+  END IF;
+
 END;
 $$   LANGUAGE plpgsql;
 

--- a/foundation-database/public/trigger_functions/trialbal.sql
+++ b/foundation-database/public/trigger_functions/trialbal.sql
@@ -6,14 +6,16 @@ DECLARE
   _accntid INTEGER[];
 BEGIN
   IF(TG_OP='DELETE') THEN
-    RAISE EXCEPTION 'You may not delete Trial Balance Transactions.';
+    IF (SELECT period_closed FROM period WHERE period_id=OLD.trialbal_period_id) THEN
+      RAISE EXCEPTION 'You may not delete Trial Balance Transactions in closed periods.';
+    END IF;
   END IF;
 
   IF (coalesce(fetchMetricValue('GLCompanySize'),0) = 0) THEN
-  --  Retained Earnings account
+  --  Get the default account number for year end closing
       _accntid := fetchmetricvalue('YearEndEquityAccount');
   ELSE
-  --  Multi-company Retained Earnings setup
+  --  Multi-company setup
       _accntid := (SELECT array_agg(company_yearend_accnt_id)
                   FROM company);
   END IF;    

--- a/test/database/triggers/trialbal.js
+++ b/test/database/triggers/trialbal.js
@@ -1,0 +1,113 @@
+/*jshint trailing:true, white:true, indent:2, strict:true, curly:true,
+  immed:true, eqeqeq:true, forin:true, latedef:true,
+  newcap:true, noarg:true, undef:true */
+/*global XT:true, after: true, describe:true, it:true, require:true, __dirname:true, before:true, console:true */
+
+var _      = require("underscore"),
+    assert = require("chai").assert,
+    path   = require("path");
+
+(function () {
+  "use strict";
+
+  describe("trialbal trigger test", function () {
+    var loginData  = require("../../lib/login_data.js").data,
+        datasource = require("../../../node-datasource/lib/ext/datasource").dataSource,
+        config     = require(path.join(__dirname, "../../../node-datasource/config.js")),
+        yearid     = -1,
+        periodid   = -1,
+        accountid    = 109, /* this is the EBank bank G/L account */
+        adminCred  = _.extend({}, config.databaseServer, {database: loginData.org});
+
+    it("should create a new fiscal Year", function (done) {
+      var sql = "SELECT createAccountingYearPeriod((SELECT yearperiod_end + 1 FROM yearperiod " +
+                                   "ORDER BY yearperiod_end DESC LIMIT 1), " +
+                                   "((SELECT yearperiod_end + 1 FROM yearperiod " +
+                                   "ORDER BY yearperiod_end DESC LIMIT 1) + '365 days'::INTERVAL)::DATE) AS year_id;";
+      datasource.query(sql, adminCred, function (err, res) {
+        assert.equal(res.rowCount, 1, "expected one year to be created");
+        yearid = res.rows[0].year_id;
+        console.log("  Fiscal Year: " + yearid);
+        assert.isTrue(yearid >= 0, "expected a fiscal yearperiod id");
+        done();
+      });
+    });
+
+    it("should create a new fiscal period in the new fiscal year", function (done) {
+      var sql = "SELECT createAccountingPeriod(yearperiod_start, " +
+                "(yearperiod_start + '1 mon'::interval)::date, $1, 1) AS period_id " +
+                "FROM yearperiod WHERE (yearperiod_id=$1);",
+          admin = _.extend({}, adminCred, { parameters: [ yearid ] });
+      datasource.query(sql, admin, function (err, res) {
+        assert.equal(res.rowCount, 1, "expected one period to be created");
+        periodid = res.rows[0].period_id;
+        assert.isTrue(periodid >= 0, "expected a fiscal period id");
+        done();
+      });
+    });
+
+    it("should create trialbal records for new fiscal period", function (done) {
+      var sql = "SELECT count(*) AS trialbal FROM trialbal WHERE trialbal_period_id=$1;",
+          reccount = -1,
+          admin = _.extend({}, adminCred, { parameters: [ periodid ] });
+      datasource.query(sql, admin, function (err, res) {
+        reccount = res.rows[0].trialbal;
+        assert.isTrue(periodid >= 0, "expected a trial balance records to be created");
+        done();
+      });
+    });
+
+    it("should prevent deletion of trialbal record from closed period", function (done) {
+      var sql = "DELETE FROM trialbal WHERE trialbal_period_id= " +
+            "(select period_id from period where period_closed order by period_end DESC LIMIT 1);";
+      datasource.query(sql, adminCred, function (err, res) {
+        assert.isNotNull(err, "expect an error deleting a trialbal record in a closed period");
+        assert.isTrue(String(err).indexOf("closed periods") > 0);
+        done();
+      });
+    });
+
+    it("should prevent editing of trialbal record in closed period", function (done) {
+      var sql = "UPDATE trialbal SET trialbal_debits=trialbal_debits + 100, trialbal_ending=trialbal_ending - 100 " +
+            "WHERE (trialbal_accnt_id=$1) AND (trialbal_period_id= " +
+            "(select period_id from period where period_closed order by period_end DESC LIMIT 1));",
+          admin = _.extend({}, adminCred, { parameters: [ accountid ] });
+      datasource.query(sql, admin, function (err, res) {
+        assert.isNotNull(err, "expect an error editing a trialbal record in a closed period");
+        assert.isTrue(String(err).indexOf("closed Period") > 0);
+        done();
+      });
+    });
+
+
+    it("should allow editing of trialbal record in open period", function (done) {
+      var sql = "SELECT forwardupdatetrialbalance(trialbal_id) FROM trialbal " +
+                "WHERE ((trialbal_period_id = $1) " +
+                "AND (trialbal_accnt_id = $2));",
+          admin = _.extend({}, adminCred, { parameters: [ periodid, accountid ] });
+      datasource.query(sql, admin, function (err, res) {
+        assert.isNull(err, "expected no error when editing a trialbal record in an open period");
+        done();
+      });
+    });
+
+    it("should allow deletion of newly created fiscal period", function (done) {
+      var sql = "SELECT deleteAccountingPeriod($1) AS result;",
+          admin = _.extend({}, adminCred, { parameters: [ periodid ] });
+      datasource.query(sql, admin, function (err, res) {
+        assert.isNull(err, "expected no error when deleting fiscal period");
+        done();
+      });
+    });
+
+    it("should allow deletion of newly created fiscal year", function (done) {
+      var sql = "SELECT deleteAccountingYearPeriod($1) AS result;",
+          admin = _.extend({}, adminCred, { parameters: [ yearid ] });
+      datasource.query(sql, admin, function (err, res) {
+        assert.isNull(err, "expected no error when deleting fiscal year");
+        done();
+      });
+    });
+
+  });
+})();


### PR DESCRIPTION
Retains the check for closed periods but excludes known conditions where trial balance records aer being updated.

Still not sure why Retained Earning accounts are updated in closed periods, but that is a separate issue.

Should upmerge this into 4_10 as well.