### PR TITLE
Resolves issue #1814

### DIFF
--- a/enyo-client/application/source/views/list_relations_box.js
+++ b/enyo-client/application/source/views/list_relations_box.js
@@ -49,6 +49,13 @@ trailing:true, white:true*/
       this.$.attachButton.hide();
       this.$.detachButton.hide();
       this.$.openButton.hide();
+      /**
+        Disable this feature (newButton) instead of repair it. Credit cards can be added to a
+        customer through the CustomerWorkspace which uses a different kind (XV.CreditCardsBox).
+        re: https://github.com/xtuple/xtuple/issues/1814
+      */
+      this.$.newButton.setDisabled(true);
+      this.$.newButton.hide();
       this.createComponent({
         kind: "XV.InputWidget",
         name: "ccv",


### PR DESCRIPTION
Removes the New button from the Credit Card box in `Sales Order` workspace and `Cash Receipt` workspace. Note that, before this change, the new button is only active if the System selected credit card company is Authoize.net. This also removes the magstripe credit card functionality because  https://github.com/xtuple/xtuple/compare/4_10_x...jcarlin:1814#diff-1b24087dfcf8768cfb194946be1b2d0dR57 ensures that https://github.com/xtuple/xtuple/blob/4_10_x/enyo-client/application/source/views/workspace.js#L2680 doesn't pass (`this.$.creditCardBox.$.newButton.disabled`).