### PR TITLE
Issue #26391: Resolve orphaned Documents/Characteristics/Comments 

### DIFF
--- a/foundation-database/manifest.js
+++ b/foundation-database/manifest.js
@@ -1067,6 +1067,7 @@
     "public/tables/cmitem.sql",
     "public/tables/cmnttypesource.sql",
     "public/tables/company.sql",
+    "public/tables/docass.sql",
     "public/tables/ipsass.sql",
     "public/tables/itemsite.sql",
     "public/tables/itemuomconv.sql",

--- a/foundation-database/public/functions/deleteso.sql
+++ b/foundation-database/public/functions/deleteso.sql
@@ -22,6 +22,17 @@ DECLARE
   _poStatus     INTEGER := 0;
 
 BEGIN
+-- These elements can be created before cohead record exists
+  DELETE FROM docass WHERE docass_source_id = pSoheadid AND docass_source_type = 'S';
+  DELETE FROM docass WHERE docass_target_id = pSoheadid AND docass_target_type = 'S';
+
+  DELETE FROM comment
+  WHERE ( (comment_source='S')
+   AND (comment_source_id=pSoheadid) );
+
+  DELETE FROM charass
+  WHERE (charass_target_type='SO')
+    AND (charass_target_id=pSoheadid);
 
 -- Get cohead
   SELECT * INTO _r FROM cohead WHERE (cohead_id=pSoheadid);
@@ -71,10 +82,6 @@ BEGIN
 
   DELETE FROM pack
   WHERE (pack_head_id=pSoheadid and pack_head_type = 'SO');
-
-  DELETE FROM charass
-  WHERE (charass_target_type='SO')
-    AND (charass_target_id=pSoheadid);
 
   DELETE FROM cohead
   WHERE (cohead_id=pSoheadid);

--- a/foundation-database/public/tables/docass.sql
+++ b/foundation-database/public/tables/docass.sql
@@ -1,0 +1,2 @@
+select xt.add_column('docass','docass_username', 'TEXT', NULL, 'public');
+select xt.add_column('docass','docass_created', 'TIMESTAMP WITH TIME ZONE', NULL, 'public');

--- a/foundation-database/public/trigger_functions/cohead.sql
+++ b/foundation-database/public/trigger_functions/cohead.sql
@@ -456,15 +456,16 @@ BEGIN
                                                                    WHEN('S') THEN 'Shipping Hold'
                                                                    ELSE 'Unknown/Error' END) ) );
       END IF;
-
-    ELSIF (TG_OP = 'DELETE') THEN
-      DELETE FROM docass WHERE docass_source_id = OLD.cohead_id AND docass_source_type = 'S';
-      DELETE FROM docass WHERE docass_target_id = OLD.cohead_id AND docass_target_type = 'S';
-
-      DELETE FROM comment
-      WHERE ( (comment_source='S')
-       AND (comment_source_id=OLD.cohead_id) );
     END IF;
+  END IF;
+
+  IF (TG_OP = 'DELETE') THEN
+    DELETE FROM docass WHERE docass_source_id = OLD.cohead_id AND docass_source_type = 'S';
+    DELETE FROM docass WHERE docass_target_id = OLD.cohead_id AND docass_target_type = 'S';
+
+    DELETE FROM comment
+    WHERE ( (comment_source='S')
+     AND (comment_source_id=OLD.cohead_id) );
   END IF;
 
   IF (TG_OP = 'UPDATE') THEN

--- a/foundation-database/public/trigger_functions/docass.sql
+++ b/foundation-database/public/trigger_functions/docass.sql
@@ -13,21 +13,20 @@ $$ LANGUAGE 'plpgsql';
 SELECT dropifexists('TRIGGER' ,'docassTrigger');
 CREATE TRIGGER docassTrigger AFTER INSERT OR UPDATE ON docass FOR EACH ROW EXECUTE PROCEDURE _docassTrigger();
 
-CREATE OR REPLACE FUNCTION _docassdeletetrigger()
+
+CREATE OR REPLACE FUNCTION _docassbeforetrigger()
   RETURNS trigger AS $$
 -- Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
 BEGIN
-  IF (TG_OP = 'DELETE') THEN
-    CASE OLD.docass_target_type
-      WHEN 'URL' THEN DELETE FROM url WHERE url_id = OLD.docass_target_id;
-      WHEN 'FILE' THEN DELETE FROM file WHERE file_id = OLD.docass_target_id;
-    END CASE;
-  END IF;
 
-  RETURN OLD;
+  NEW.docass_username := geteffectivextuser();
+  NEW.docass_created  := (SELECT CURRENT_TIMESTAMP);
+
+  RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
-SELECT dropifexists('TRIGGER' ,'docassdeleteTrigger');
-CREATE TRIGGER docassdeleteTrigger AFTER DELETE ON docass FOR EACH ROW EXECUTE PROCEDURE _docassdeleteTrigger();
+SELECT dropifexists('TRIGGER' ,'docassbeforeTrigger');
+CREATE TRIGGER docassbeforeTrigger BEFORE INSERT ON docass FOR EACH ROW EXECUTE PROCEDURE _docassbeforetrigger();
+

--- a/foundation-database/public/trigger_functions/docass.sql
+++ b/foundation-database/public/trigger_functions/docass.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE FUNCTION _docassTrigger () RETURNS TRIGGER AS $$
--- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple. 
+-- Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
 BEGIN
   IF (NEW.docass_source_type = 'INCDT') THEN
@@ -12,3 +12,22 @@ $$ LANGUAGE 'plpgsql';
 
 SELECT dropifexists('TRIGGER' ,'docassTrigger');
 CREATE TRIGGER docassTrigger AFTER INSERT OR UPDATE ON docass FOR EACH ROW EXECUTE PROCEDURE _docassTrigger();
+
+CREATE OR REPLACE FUNCTION _docassdeletetrigger()
+  RETURNS trigger AS $$
+-- Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple.
+-- See www.xtuple.com/CPAL for the full text of the software license.
+BEGIN
+  IF (TG_OP = 'DELETE') THEN
+    CASE OLD.docass_target_type
+      WHEN 'URL' THEN DELETE FROM url WHERE url_id = OLD.docass_target_id;
+      WHEN 'FILE' THEN DELETE FROM file WHERE file_id = OLD.docass_target_id;
+    END CASE;
+  END IF;
+
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT dropifexists('TRIGGER' ,'docassdeleteTrigger');
+CREATE TRIGGER docassdeleteTrigger AFTER DELETE ON docass FOR EACH ROW EXECUTE PROCEDURE _docassdeleteTrigger();


### PR DESCRIPTION
When cancelling or deleting a S/O documents/characteristics/comments remained in the Db as orphans.

This PR also resolves the issue when you delete a Document with an assigned File or URL - that file/url was also left orphaned in the database.  There was a question over whether we wanted the file to remain in the Db orphaned if it was something important.