### PR TITLE
Issue #26757: PO Return Valuation

### DIFF
--- a/foundation-database/manifest.js
+++ b/foundation-database/manifest.js
@@ -1412,6 +1412,7 @@
     "public/tables/metasql/taxAuthorities-detail.mql",
     "public/tables/metasql/taxBreakdown-detail.mql",
     "public/tables/metasql/taxHistory-detail.mql",
+    "public/tables/metasql/taxReturn-detail.mql",
     "public/tables/metasql/timePhasedAvailability-detail.mql",
     "public/tables/metasql/timePhasedBookings-detail.mql",
     "public/tables/metasql/timePhasedSales-detail.mql",

--- a/foundation-database/public/functions/postporeturns.sql
+++ b/foundation-database/public/functions/postporeturns.sql
@@ -76,7 +76,7 @@ BEGIN
        AND (itemsite_id=_p.itemsiteid) );
 
       UPDATE poreject
-      SET poreject_posted=TRUE, poreject_value=(invhist_unitcost *_p.totalqty * _p.poitem_invvenduomratio)
+      SET poreject_posted=TRUE, poreject_value= round(_p.poitem_unitprice_base * _p.totalqty, 2)
       FROM invhist
       WHERE ((poreject_id=_p.poreject_id)
       AND (invhist_id=_returnval));


### PR DESCRIPTION
PO Return for inventory controlled items was valuing at standard cost not Purchase Order Item price.  This means Credit Memos created as a result do not match the PO and Voucher pricing.