### PR TITLE
issue #26631, issue #26823 - Resolve license count issue when a qt-client session creates multiple locks

### DIFF
--- a/foundation-database/public/functions/numofdatabaseusers.sql
+++ b/foundation-database/public/functions/numofdatabaseusers.sql
@@ -1,5 +1,5 @@
 ﻿CREATE OR REPLACE FUNCTION numOfDatabaseUsers() RETURNS INTEGER AS $$
--- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple. 
+-- Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
 BEGIN
   RETURN numOfDatabaseUsers(NULL);
@@ -7,7 +7,7 @@ END;
 $$ LANGUAGE 'plpgsql';
 
 CREATE OR REPLACE FUNCTION numOfDatabaseUsers(pAppName TEXT) RETURNS INTEGER AS $$
--- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple. 
+-- Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
 DECLARE
   _count INTEGER;
@@ -17,7 +17,7 @@ BEGIN
   -- in version 9.2.0 the column "procpid" was changed to just "pid" Incident #21852
   IF (compareversion('9.2.0') <= 0)
   THEN
-  SELECT count(*)
+  SELECT count(DISTINCT pg_locks.pid)
     INTO _count
     FROM pg_locks
     LEFT JOIN pg_stat_activity ON pg_stat_activity.pid = pg_locks.pid
@@ -26,7 +26,7 @@ BEGIN
      AND (pg_stat_activity.datname = current_database())
      AND CASE WHEN (trim(coalesce(pAppName, '')) = '') THEN true ELSE application_name = pAppName END;
   ELSE
-  SELECT count(*)
+  SELECT count(DISTINCT pg_locks.pid)
     INTO _count
     FROM pg_locks    
     LEFT JOIN pg_stat_activity ON pg_stat_activity.procpid = pg_locks.pid


### PR DESCRIPTION
Observed a single qt-client login created multiple locks which impacts the license count.  Using distinct pids resolves this scenario while still correctly checking if a user does log in multiple times.