### PR TITLE
issue #26887 - rework _docinfo() to improve perf and eliminate redundancy

### DIFF
--- a/foundation-database/manifest.js
+++ b/foundation-database/manifest.js
@@ -47,6 +47,7 @@
     "public/indexes/womatlpost.sql",
 
     "public/types/_docinfo.sql",
+    "public/types/_targetdoc.sql",
     "public/types/achline.sql",
     "public/types/apaging.sql",
     "public/types/araging.sql",
@@ -68,6 +69,7 @@
     "public/types/woinvav.sql",
 
     "public/functions/_docinfo.sql",
+    "public/functions/_gettargetdocument.sql",
     "public/functions/_normalizeversion.sql",
     "public/functions/acknowledgemessage.sql",
     "public/functions/actcost.sql",

--- a/foundation-database/public/functions/_docinfo.sql
+++ b/foundation-database/public/functions/_docinfo.sql
@@ -2,7 +2,7 @@ DROP VIEW IF EXISTS docinfo;
 DROP FUNCTION IF EXISTS _docinfo(INTEGER, TEXT);
 CREATE OR REPLACE FUNCTION _docinfo(pRefId INTEGER, pRefType TEXT, pRecursive BOOLEAN = false)
   RETURNS SETOF _docinfo AS
-$BODY$
+$$
 DECLARE
   _crmacct      RECORD;
   _id           INTEGER;
@@ -144,5 +144,5 @@ BEGIN
   END IF;
 
   END;
-$BODY$ LANGUAGE plpgsql VOLATILE;
+$$ LANGUAGE plpgsql;
 

--- a/foundation-database/public/functions/_docinfo.sql
+++ b/foundation-database/public/functions/_docinfo.sql
@@ -7,7 +7,7 @@ DECLARE
   _crmacct      RECORD;
   _id           INTEGER;
   _column       TEXT;
-  _row          _docinfo;
+  _row          _docinfo%ROWTYPE;
   _target       RECORD;
 BEGIN
 

--- a/foundation-database/public/functions/_gettargetdocument.sql
+++ b/foundation-database/public/functions/_gettargetdocument.sql
@@ -1,0 +1,59 @@
+﻿CREATE OR REPLACE FUNCTION _gettargetdocument(pDocAssId INTEGER, pSourceId INTEGER)
+  RETURNS SETOF _targetdoc AS
+$BODY$
+
+DECLARE
+  _targetId INTEGER;
+  _baseq    TEXT := NULL;
+  _query    TEXT := NULL;
+  _src      RECORD;
+  _row      _targetdoc%ROWTYPE;
+
+BEGIN
+
+  SELECT * INTO _src FROM source WHERE source_id = pSourceId;
+
+  IF (NOT FOUND) THEN
+    RAISE EXCEPTION 'Invalid source_id [xtuple: _gettargetdocument, -2, %]',
+                    pSourceId;
+  END IF;
+
+  SELECT CASE _src.source_docass WHEN docass_target_type THEN docass_target_id
+         ELSE docass_source_id
+         END INTO _targetId
+    FROM docass
+   WHERE docass_id = pDocAssId;
+
+  IF (NOT FOUND) THEN
+    RAISE EXCEPTION 'Invalid docass_id [xtuple: _gettargetdocument, -1, %]',
+                    pDocAssId;
+  END IF;
+
+  _baseq = $$
+           SELECT %s AS target_docass_id,
+                  %s AS target_source_id,
+                  %s AS target_doc_number,
+                  %s AS target_doc_name,
+                  %s AS target_doc_descrip
+             FROM %s
+             %s
+            WHERE %s = %s;
+           $$;
+
+  _query = format(_baseq, pDocAssId, pSourceId,
+                  _src.source_number_field, _src.source_name_field,
+                  _src.source_desc_field, _src.source_table,
+                  coalesce(_src.source_joins, ''), _src.source_key_field,
+                  _targetId);
+  RAISE DEBUG '%', _query;
+
+  FOR _row IN EXECUTE(_query)
+  LOOP
+    RETURN NEXT _row;
+  END LOOP;
+
+END;
+$BODY$
+  LANGUAGE 'plpgsql' VOLATILE
+  COST 100;
+

--- a/foundation-database/public/functions/_gettargetdocument.sql
+++ b/foundation-database/public/functions/_gettargetdocument.sql
@@ -1,7 +1,5 @@
 ﻿CREATE OR REPLACE FUNCTION _gettargetdocument(pDocAssId INTEGER, pSourceId INTEGER)
-  RETURNS SETOF _targetdoc AS
-$BODY$
-
+  RETURNS SETOF _targetdoc AS $$
 DECLARE
   _targetId INTEGER;
   _baseq    TEXT := NULL;
@@ -29,7 +27,7 @@ BEGIN
                     pDocAssId;
   END IF;
 
-  _baseq = $$
+  _baseq = $Q$
            SELECT %s AS target_docass_id,
                   %s AS target_source_id,
                   %s AS target_doc_number,
@@ -38,7 +36,7 @@ BEGIN
              FROM %s
              %s
             WHERE %s = %s;
-           $$;
+           $Q$;
 
   _query = format(_baseq, pDocAssId, pSourceId,
                   _src.source_number_field, _src.source_name_field,
@@ -53,7 +51,5 @@ BEGIN
   END LOOP;
 
 END;
-$BODY$
-  LANGUAGE 'plpgsql' VOLATILE
-  COST 100;
-
+$$
+LANGUAGE plpgsql;

--- a/foundation-database/public/types/_targetdoc.sql
+++ b/foundation-database/public/types/_targetdoc.sql
@@ -1,0 +1,6 @@
+﻿DROP TYPE IF EXISTS _targetdoc;
+CREATE TYPE _targetdoc AS (target_docass_id INTEGER,
+                           target_source_id INTEGER,
+                           target_doc_number TEXT,
+                           target_doc_name TEXT,
+                           target_doc_descrip TEXT);

--- a/foundation-database/public/views/docinfo.sql
+++ b/foundation-database/public/views/docinfo.sql
@@ -1,56 +1,27 @@
-CREATE OR REPLACE VIEW docinfo AS SELECT
-  id,
-  target_number,
-  target_type,
-  target_id,
-  source_type_docinfo,
-  source_id_docinfo,
-  name,
-  description,
-  purpose,
-  source_type,
-  source_id
-FROM (
-  SELECT
-    (unnest(_docinfo)).id,
-    (unnest(_docinfo)).target_number,
-    (unnest(_docinfo)).target_type,
-    (unnest(_docinfo)).target_id,
-    (unnest(_docinfo)).source_type AS source_type_docinfo,
-    (unnest(_docinfo)).source_id AS source_id_docinfo,
-    (unnest(_docinfo)).name,
-    (unnest(_docinfo)).description,
-    (unnest(_docinfo)).purpose,
-    source_type,
-    source_id
-  FROM (
-    SELECT DISTINCT
-      *,
-      ARRAY(SELECT _docinfo(docass_source_id, docass_source_type)) AS _docinfo
-    FROM (
-      SELECT
-        docass_source_type,
-        docass_source_id,
-        docass_source_type AS source_type, -- Hack to pass docass_source_type to outer_wapper where clause
-        docass_source_id AS source_id -- Hack to pass docass_source_id to outer_wapper where clause
-      FROM docass
-      UNION ALL
-      SELECT
-        imageass_source AS docass_source_type,
-        imageass_source_id AS docass_source_id,
-        imageass_source AS source_type, -- Hack to pass docass_source_type to outer_wapper where clause
-        imageass_source_id AS source_id -- Hack to pass docass_source_id to outer_wapper where clause
-      FROM imageass
-      UNION ALL
-      SELECT
-        url_source AS docass_source_type,
-        url_source_id AS docass_source_id,
-        url_source AS source_type, -- Hack to pass docass_source_type to outer_wapper where clause
-        url_source_id AS source_id -- Hack to pass docass_source_id to outer_wapper where clause
-      FROM url
-    ) AS docinfo
-  ) AS inner_wrapper
-) AS outer_wrapper;
+DROP VIEW IF EXISTS docinfo;
+CREATE OR REPLACE VIEW docinfo AS
+    SELECT (_docinfo).id,
+           (_docinfo).target_number,
+           (_docinfo).target_type,
+           (_docinfo).target_id,
+           (_docinfo).source_type,
+           (_docinfo).source_id,
+           (_docinfo).name,
+           (_docinfo).description,
+           (_docinfo).purpose
+      FROM (SELECT DISTINCT _docinfo(id, type)
+              FROM (
+                  SELECT docass_source_id AS id,   docass_source_type AS type
+                    FROM docass
+                  UNION
+                  SELECT docass_target_id AS id,   docass_target_type AS type
+                    FROM docass
+                  UNION
+                  SELECT imageass_source_id AS id, imageass_source AS type
+                    FROM imageass
+                  UNION
+                  SELECT url_source_id AS id,      url_source AS type
+                    FROM url
+                  ) inner_docinfo
+           ) outer_docinfo;
 
-REVOKE ALL ON TABLE docinfo FROM PUBLIC;
-GRANT  ALL ON TABLE docinfo TO GROUP xtrole;

--- a/test/database/docinfo.sql
+++ b/test/database/docinfo.sql
@@ -52,11 +52,28 @@ var _ = require("underscore"),
       });
     });
 
-    it('should be retrievable from the view', function (done) {
-      var sql = "select * from docinfo;";
+    it('should be retrievable from the view (but slow)', function (done) {
+      var sql = "select *"
+              + "  from docinfo"
+              + " where source_id = (SELECT docass_source_id FROM docass"
+              + "                      where docass_source_type = 'C' limit 1)"
+              + "   and source_type = 'C';";
       creds.database = databaseName;
       datasource.query(sql, creds, function (err, res) {
         assert.isNull(err);
+        assert(res.rowCount >= 1);
+        done();
+      });
+    });
+
+    it('should get 2+ rows for a customer', function (done) {
+      var sql = "select *"
+              + "  from _docinfo((select docass_source_id from docass"
+              + "                 where docass_source_type = 'C' limit 1), 'C');";
+      creds.database = databaseName;
+      datasource.query(sql, creds, function (err, res) {
+        assert.isNull(err);
+        assert(res.rowCount >= 2);
         done();
       });
     });


### PR DESCRIPTION
This approach was suggested by @paladinlogic - query the docass and source tables to get the associations, then retrieve detail from various tables individually. The performance selecting directly from the `docinfo` view is terrible. The performance selecting from the `_docinfo(id, type)` function is much better.

Test results on one large database indicate between 1 and 5 orders of magnitude performance, depending on the particular records.

See accompanying xtuple/qt-client#1072