### PR TITLE
Issue #27478: Resolve API.project inconsistency

### DIFF
--- a/foundation-database/api/views/project.sql
+++ b/foundation-database/api/views/project.sql
@@ -17,7 +17,7 @@ AS
        WHEN (prj_status = 'O') THEN
          'In-Process'
        WHEN (prj_status = 'C') THEN
-         'Closed'
+         'Completed'
        ELSE
          'Error'
      END AS status,


### PR DESCRIPTION
Everywhere else refers to status C = 'Completed'