### PR TITLE
issue #27541 - postgres 9.5 raise needs arg counts to agree

### DIFF
--- a/foundation-database/api/views/creditmemoline.sql
+++ b/foundation-database/api/views/creditmemoline.sql
@@ -36,7 +36,7 @@ COMMENT ON VIEW api.creditmemoline IS 'Credit Memo Line';
 
 CREATE OR REPLACE FUNCTION insertcreditmemoline(api.creditmemoline) RETURNS boolean AS
 $insertcreditmemoline$
--- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+-- Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
 DECLARE
   pNew ALIAS FOR $1;
@@ -48,7 +48,8 @@ BEGIN
   FROM cmhead
   WHERE (cmhead_id=getCmheadId(pNew.memo_number, FALSE));
   IF (NOT FOUND) THEN
-    RAISE EXCEPTION 'Credit Memo # % not found', pNew.memo_number;
+    RAISE EXCEPTION 'Credit Memo # % not found [xtuple: insertCreditMemoLine, -1, %]',
+                    pNew.memo_number, pNew.memo_number;
   END IF;
 
   INSERT INTO cmitem ( cmitem_cmhead_id,
@@ -113,7 +114,8 @@ BEGIN
   FROM cmitem
   WHERE ( (cmitem_cmhead_id=getCmheadId(pOld.memo_number, FALSE)) AND (cmitem_linenumber=pOld.line_number) );
   IF (NOT FOUND) THEN
-    RAISE EXCEPTION 'Credit Memo # % Line Number # not found', pOld.memo_number, pOld.line_number;
+    RAISE EXCEPTION 'Credit Memo % Line % not found [xtuple: updateCreditMemoLine, -1, %, %]',
+                     pOld.memo_number, pOld.line_number, pOld.memo_number, pOld.line_number;
   END IF;
 
   UPDATE cmitem

--- a/foundation-database/public/functions/insertitemcost.sql
+++ b/foundation-database/public/functions/insertitemcost.sql
@@ -46,26 +46,22 @@ BEGIN
                     pItemId, pCostElemId;
   END IF;
 
-  IF (pCost > 0) THEN
-    SELECT NEXTVAL('itemcost_itemcost_id_seq') INTO _itemcost_id;
-    INSERT INTO itemcost
-      ( itemcost_id, itemcost_item_id, itemcost_costelem_id, itemcost_lowlevel,
-        itemcost_stdcost, itemcost_posted, itemcost_actcost, itemcost_updated, itemcost_curr_id )
-    VALUES
-      ( _itemcost_id, pItemId, pCostElemId, FALSE,
-        0, startOfTime(), pCost, CURRENT_DATE, pCurrId );
+  SELECT NEXTVAL('itemcost_itemcost_id_seq') INTO _itemcost_id;
+  INSERT INTO itemcost
+    ( itemcost_id, itemcost_item_id, itemcost_costelem_id, itemcost_lowlevel,
+      itemcost_stdcost, itemcost_posted, itemcost_actcost, itemcost_updated, itemcost_curr_id )
+  VALUES
+    ( _itemcost_id, pItemId, pCostElemId, FALSE,
+      0, startOfTime(), pCost, CURRENT_DATE, pCurrId );
 
-    --Only Post Cost to standard if the parameter is set to true
-    IF (pPostToStandard) THEN
-      IF (NOT checkPrivilege('PostStandardCosts')) THEN
-        RAISE EXCEPTION 'You do not have privileges to post standard itemcosts. Set api.itemcost post_to_standard to false [xtuple: insertItemCost, -7]';
-      END IF;
-      IF NOT postcost(_itemcost_id) THEN
-        RAISE EXCEPTION 'Posting standard cost failed [xtuple: insertItemCost, -2, %, %]', pItemId, pCostElemId;
-      END IF;
+  --Only Post Cost to standard if the parameter is set to true
+  IF (pPostToStandard) THEN
+    IF (NOT checkPrivilege('PostStandardCosts')) THEN
+      RAISE EXCEPTION 'You do not have privileges to post standard itemcosts. Set api.itemcost post_to_standard to false [xtuple: insertItemCost, -7]';
     END IF;
-  ELSE
-    RAISE EXCEPTION 'Cannot set a negative or 0 item cost [xtuple: insertItemCost, -1, %, %]', pItemId, pCostElemId;
+    IF NOT postcost(_itemcost_id) THEN
+      RAISE EXCEPTION 'Posting standard cost failed [xtuple: insertItemCost, -2, %, %]', pItemId, pCostElemId;
+    END IF;
   END IF;
 
   RETURN _itemcost_id;

--- a/foundation-database/public/functions/insertitemcost.sql
+++ b/foundation-database/public/functions/insertitemcost.sql
@@ -1,22 +1,17 @@
-CREATE OR REPLACE FUNCTION insertItemCost(INTEGER, INTEGER, INTEGER, NUMERIC, BOOLEAN) RETURNS INTEGER AS $BODY$
--- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple. 
+DROP FUNCTION IF EXISTS insertItemCost(INTEGER, INTEGER, INTEGER, NUMERIC, BOOLEAN) CASCADE;
+CREATE OR REPLACE FUNCTION insertItemCost(pItemId INTEGER, pCostElemId INTEGER, pCurrId INTEGER, pCost NUMERIC, pPostToStandard BOOLEAN) RETURNS INTEGER AS $BODY$
+-- Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
 DECLARE
-pItemId ALIAS FOR $1;
-pCostElemId ALIAS FOR $2;
-pCurrId ALIAS FOR $3;
-pCost ALIAS FOR $4;
-pPostToStandard ALIAS FOR $5;
 _itemcost_id INTEGER;
-_update_return INTEGER;
-_postcost_return BOOLEAN;
 
 --This function is used with the api.itemcost View for updating and inserting
 --into the itemcosts table
 
 BEGIN
   IF (pCost IS NULL OR pCost < 0) THEN
-    RAISE EXCEPTION 'itemcost Actual Cost Invalid ', pCost;
+    RAISE EXCEPTION 'itemcost Actual Cost % Invalid [xtuple: insertItemCost, -4, %, %, %]',
+                    pCost, pItemId, pCostElemId, pCost;
   END IF;
 
 -- Check for uniqueness
@@ -26,7 +21,8 @@ BEGIN
     AND   (itemcost_costelem_id = pCostElemId)
     AND   (NOT itemcost_lowlevel) );
   IF (FOUND) THEN
-    RAISE EXCEPTION 'itemcost already exists for this Item and Cost Element';
+    RAISE EXCEPTION 'itemcost already exists for this Item and Cost Element [xtuple: insertItemCost, -3, %, %]',
+                     pItemId, pCostElemId;
   END IF;
 
 -- Check for valid combination of item_type and costelem_type
@@ -36,18 +32,20 @@ BEGIN
         AND (costelem_id=pCostElemId)
         AND (item_type IN ('M', 'F', 'B', 'C', 'T'))
         AND (costelem_type IN ('Material'))) THEN
-    RAISE EXCEPTION 'itemcost of this type is invalid for Manufactured Item';
+    RAISE EXCEPTION 'itemcost of this type is invalid for Manufactured Item [xtuple: insertItemCost, -5, %, %]',
+                    pItemId, pCostElemId;
   END IF;
-  
+
   IF (SELECT (COUNT(*) > 0)
       FROM item, costelem
       WHERE (item_id=pItemId)
         AND (costelem_id=pCostElemId)
         AND (item_type IN ('O', 'P'))
         AND (costelem_type IN ('Direct Labor', 'Overhead', 'Machine Overhead'))) THEN
-    RAISE EXCEPTION 'itemcost of this type is invalid for Purchased Item';
+    RAISE EXCEPTION 'itemcost of this type is invalid for Purchased Item [xtuple: insertItemCost, -6, %, %]',
+                    pItemId, pCostElemId;
   END IF;
-  
+
   IF (pCost > 0) THEN
     SELECT NEXTVAL('itemcost_itemcost_id_seq') INTO _itemcost_id;
     INSERT INTO itemcost
@@ -60,19 +58,18 @@ BEGIN
     --Only Post Cost to standard if the parameter is set to true
     IF (pPostToStandard) THEN
       IF (NOT checkPrivilege('PostStandardCosts')) THEN
-        RAISE EXCEPTION 'You do not have privileges to poststandard itemcosts. Set api.itemcost post_to_standard to false';
+        RAISE EXCEPTION 'You do not have privileges to post standard itemcosts. Set api.itemcost post_to_standard to false [xtuple: insertItemCost, -7]';
       END IF;
-      SELECT postcost(_itemcost_id) INTO _postcost_return;       
-      IF (NOT _postcost_return) THEN
-        RETURN -2;
+      IF NOT postcost(_itemcost_id) THEN
+        RAISE EXCEPTION 'Posting standard cost failed [xtuple: insertItemCost, -2, %, %]', pItemId, pCostElemId;
       END IF;
     END IF;
-  ELSE 
-    RETURN -1;
+  ELSE
+    RAISE EXCEPTION 'Cannot set a negative or 0 item cost [xtuple: insertItemCost, -1, %, %]', pItemId, pCostElemId;
   END IF;
 
   RETURN _itemcost_id;
-  
+
 END;
 $BODY$
-  LANGUAGE 'plpgsql';
+  LANGUAGE plpgsql;

--- a/foundation-database/public/functions/updateitemcost.sql
+++ b/foundation-database/public/functions/updateitemcost.sql
@@ -24,23 +24,19 @@ BEGIN
                      pCost, pItemId, pCostElemId;
   END IF;
 
-  IF (pCost > 0) THEN
-    UPDATE itemcost
-    SET itemcost_actcost=pCost,
-        itemcost_curr_id = pCurrId
-    WHERE (itemcost_id=_itemcost_id);
+  UPDATE itemcost
+  SET itemcost_actcost=pCost,
+      itemcost_curr_id = pCurrId
+  WHERE (itemcost_id=_itemcost_id);
 
-    --Only Post Cost to standard if the parameter is set to true
-    IF (pPostToStandard) THEN
-      IF (NOT checkPrivilege('PostStandardCosts')) THEN
-        RAISE EXCEPTION 'You do not have privileges to post standard itemcosts. Set api.itemcost post_to_standard to false [xtuple: updateItemCost, -5]';
-      END IF;
-      IF NOT postcost(_itemcost_id) THEN
-        RAISE EXCEPTION 'Posting standard cost failed [xtuple: updateItemCost, -2, %, %]', pItemId, pCostElemId;
-      END IF;
+  --Only Post Cost to standard if the parameter is set to true
+  IF (pPostToStandard) THEN
+    IF (NOT checkPrivilege('PostStandardCosts')) THEN
+      RAISE EXCEPTION 'You do not have privileges to post standard itemcosts. Set api.itemcost post_to_standard to false [xtuple: updateItemCost, -5]';
     END IF;
-  ELSE
-    RAISE EXCEPTION 'Cannot set a negative or 0 item cost [xtuple: updateItemCost, -1, %, %]', pItemId, pCostElemId;
+    IF NOT postcost(_itemcost_id) THEN
+      RAISE EXCEPTION 'Posting standard cost failed [xtuple: updateItemCost, -2, %, %]', pItemId, pCostElemId;
+    END IF;
   END IF;
 
   RETURN _itemcost_id;

--- a/foundation-database/public/functions/updateitemcost.sql
+++ b/foundation-database/public/functions/updateitemcost.sql
@@ -1,15 +1,10 @@
-CREATE OR REPLACE FUNCTION UpdateItemCost(INTEGER, INTEGER, INTEGER, NUMERIC, BOOLEAN) RETURNS INTEGER AS $BODY$
--- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple. 
+DROP FUNCTION IF EXISTS updateItemCost(INTEGER, INTEGER, INTEGER, NUMERIC, BOOLEAN) CASCADE;
+CREATE OR REPLACE FUNCTION updateItemCost(pItemId INTEGER, pCostElemId INTEGER, pCurrId INTEGER, pCost NUMERIC, pPostToStandard BOOLEAN) RETURNS INTEGER AS $BODY$
+-- Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
 DECLARE
-pItemId ALIAS FOR $1;
-pCostElemId ALIAS FOR $2;
-pCurrId ALIAS FOR $3;
-pCost ALIAS FOR $4;
-pPostToStandard ALIAS FOR $5;
 _itemcost_id INTEGER;
 _update_return INTEGER;
-_postcost_return BOOLEAN;
 
 --This function is used with the api.itemcost View for updating
 --the itemcost table
@@ -20,13 +15,15 @@ BEGIN
   WHERE ( (itemcost_item_id = pItemId) AND (itemcost_costelem_id = pCostElemId) );
 
   IF (NOT FOUND) THEN
-    RAISE EXCEPTION 'itemcost % not found for. ', pItemId || ' & ' || pCostElemId;
+    RAISE EXCEPTION 'itemcost % not found for % [xtuple: updateItemCost, -3, %, %]',
+                    pCostElemId, pItemId, pItemId, pCostElemId;
   END IF;
 
   IF (pCost IS NULL OR pCost < 0) THEN
-    RAISE EXCEPTION 'itemcost Actual Cost Invalid ', pCost;
+    RAISE EXCEPTION 'itemcost Actual Cost Invalid % [xtuple: updateItemCost, -4, %, %]',
+                     pCost, pItemId, pCostElemId;
   END IF;
-  
+
   IF (pCost > 0) THEN
     UPDATE itemcost
     SET itemcost_actcost=pCost,
@@ -36,19 +33,18 @@ BEGIN
     --Only Post Cost to standard if the parameter is set to true
     IF (pPostToStandard) THEN
       IF (NOT checkPrivilege('PostStandardCosts')) THEN
-        RAISE EXCEPTION 'You do not have privileges to poststandard itemcosts. Set api.itemcost post_to_standard to false';
+        RAISE EXCEPTION 'You do not have privileges to post standard itemcosts. Set api.itemcost post_to_standard to false [xtuple: updateItemCost, -5]';
       END IF;
-      SELECT postcost(_itemcost_id) INTO _postcost_return;       
-      IF (NOT _postcost_return) THEN
-        RETURN -2;
+      IF NOT postcost(_itemcost_id) THEN
+        RAISE EXCEPTION 'Posting standard cost failed [xtuple: updateItemCost, -2, %, %]', pItemId, pCostElemId;
       END IF;
     END IF;
-  ELSE 
-    RETURN -1;
+  ELSE
+    RAISE EXCEPTION 'Cannot set a negative or 0 item cost [xtuple: updateItemCost, -1, %, %]', pItemId, pCostElemId;
   END IF;
 
   RETURN _itemcost_id;
-  
+
 END;
 $BODY$
-  LANGUAGE 'plpgsql';
+  LANGUAGE plpgsql;

--- a/scripts/install_xtuple.sh
+++ b/scripts/install_xtuple.sh
@@ -147,6 +147,12 @@ install_packages() {
   sudo add-apt-repository -y "deb http://apt.postgresql.org/pub/repos/apt/ ${DEBDIST}-pgdg main"
   sudo wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
   sudo apt-get -qq update 2>&1 | tee -a $LOG_FILE
+
+  # we won't support pg 9.1 in 4.10 or later
+  if [ ${PG_VERSION} != 9.1 ] ; then
+    sudo apt-get -q -y remove postgresql-9.1
+  fi
+
   sudo apt-get -q -y install curl build-essential libssl-dev \
     postgresql-${PG_VERSION} postgresql-server-dev-${PG_VERSION} \
     postgresql-${PG_VERSION}-asn1oid postgresql-contrib-${PG_VERSION} 2>&1 \

--- a/scripts/install_xtuple.sh
+++ b/scripts/install_xtuple.sh
@@ -150,7 +150,9 @@ install_packages() {
 
   # we won't support pg 9.1 in 4.10 or later
   if [ ${PG_VERSION} != 9.1 ] ; then
-    sudo apt-get -q -y remove postgresql-9.1
+    sudo apt-get -q -y remove postgresql-9.1 postgresql-server-dev-9.1 \
+      postgresql-client-9.1 postgresql-contrib-9.1 \
+      postgresql-9.1-asn1oid postgresql-9.1-plv8 2>&1
   fi
 
   sudo apt-get -q -y install curl build-essential libssl-dev \

--- a/scripts/install_xtuple.sh
+++ b/scripts/install_xtuple.sh
@@ -46,7 +46,7 @@ cdir() {
   log "Changing directory to $1"
 }
 
-PG_VERSION=9.1
+PG_VERSION=9.3
 DATABASE=dev
 RUNALL=true
 XT_VERSION=
@@ -149,7 +149,10 @@ install_packages() {
   sudo apt-get -qq update 2>&1 | tee -a $LOG_FILE
   sudo apt-get -q -y install curl build-essential libssl-dev \
     postgresql-${PG_VERSION} postgresql-server-dev-${PG_VERSION} \
-    postgresql-contrib-${PG_VERSION} postgresql-${PG_VERSION}-plv8 2>&1 \
+    postgresql-${PG_VERSION}-asn1oid postgresql-contrib-${PG_VERSION} 2>&1 \
+    | tee -a $LOG_FILE
+
+  sudo apt-get -q -y install postgresql-${PG_VERSION}-plv8 2>&1 \
     | tee -a $LOG_FILE
 
   if [ ! -d "/usr/local/nvm" ]; then
@@ -235,9 +238,8 @@ setup_postgres() {
   log "restarting postgres..."
   sudo service postgresql restart
 
-# --if-exists does not exist in 9.1, which we still support
   log "dropping existing db, if any..."
-  dropdb -U postgres $DATABASE || true
+  dropdb -U postgres --if-exists $DATABASE
 
   cdir $BASEDIR/postgres
 

--- a/test/database/functions/insertitemcost.sql
+++ b/test/database/functions/insertitemcost.sql
@@ -1,0 +1,148 @@
+var _ = require("underscore"),
+  assert = require('chai').assert,
+  path = require('path');
+
+(function () {
+  "use strict";
+  describe('insertItemCost()', function () {
+
+    var loginData = require(path.join(__dirname, "../../lib/login_data.js")).data,
+      datasource = require('../../../node-datasource/lib/ext/datasource').dataSource,
+      config = require(path.join(__dirname, "../../../node-datasource/config.js")),
+      creds = _.extend({}, config.databaseServer, {database: loginData.org}),
+      canPost = false,
+      mfgItemId  = -1,
+      purItemId  = -1;
+
+    it("should check if we have PostStandardCosts", function (done) {
+      var sql = "select checkPrivilege('PostStandardCosts') as result;";
+      datasource.query(sql, creds, function (err, res) {
+        assert.isNull(err);
+        canPost = res.rows[0].result;
+        done();
+      });
+    });
+
+    it("should reject null cost", function (done) {
+      var sql = "select insertItemCost(NULL, NULL, NULL, NULL, NULL) as result;";
+      datasource.query(sql, creds, function (err, res) {
+        assert.isNotNull(err);
+        assert.match(err, /insertitemcost.*-4[^0-9]/i);
+        done();
+      });
+    });
+
+    it("should reject negative cost", function (done) {
+      var sql = "select insertItemCost(-1, NULL, NULL, NULL, NULL) as result;";
+      datasource.query(sql, creds, function (err, res) {
+        assert.isNotNull(err);
+        assert.match(err, /insertitemcost.*-4[^0-9]/i);
+        done();
+      });
+    });
+
+    it("should reject 0 cost", function (done) {
+      var sql = "select insertItemCost(0, NULL, NULL, NULL, NULL) as result;";
+      datasource.query(sql, creds, function (err, res) {
+        assert.isNotNull(err);
+        assert.match(err, /insertitemcost.*-4[^0-9]/i);
+        done();
+      });
+    });
+
+    it("should reject existing cost", function (done) {
+      var sql = "select insertItemCost(itemcost_item_id, itemcost_costelem_id, itemcost_curr_id, itemcost_actcost, TRUE) as result"
+              + "  FROM itemcost limit 1;";
+      datasource.query(sql, creds, function (err, res) {
+        assert.isNotNull(err);
+        assert.match(err, /insertitemcost.*-3[^0-9]/i);
+        done();
+      });
+    });
+
+    it("should reject mismatched item_type,costelem_type for Manufactured items", function (done) {
+      var sql = "select insertItemCost(item_id, costelem_id, basecurrid(), 1.23, TRUE) as result"
+              + "  from item, costelem"
+              + " where item_type in ('M', 'F', 'B', 'C', 'T')"
+              + "   and costelem_type = 'Material'"
+;
+      datasource.query(sql, creds, function (err, res) {
+        assert.isNotNull(err);
+        assert.match(err, /insertitemcost.*-5[^0-9]/i);
+        done();
+      });
+    });
+
+    it("should reject mismatched item_type,costelem_type for purchased items", function (done) {
+      var sql = "select insertItemCost(item_id, costelem_id, basecurrid(), 1.23, TRUE) as result"
+              + "  from item, costelem"
+              + " where item_type in ('O', 'P')"
+              + "   and costelem_type in ('Direct Labor', 'Overhead', 'Machine Overhead')"
+;
+      datasource.query(sql, creds, function (err, res) {
+        assert.isNotNull(err);
+        assert.match(err, /insertitemcost.*-6[^0-9]/i);
+        done();
+      });
+    });
+
+    it("should get a manufactured item with no cost elements", function (done) {
+      var sql = "select item_id, item_type from item"
+              + " where item_type = 'M'"
+              + "   and item_id not in (select itemcost_item_id from itemcost);";
+      datasource.query(sql, creds, function (err, res) {
+        assert.isNull(err);
+        assert(res.rowCount > 0);
+        mfgItemId = res.rows[0].item_id;
+        console.log("Manufactured: " + mfgItemId);
+        done();
+      });
+    });
+
+    it("should get a purchased item with no cost elements", function (done) {
+      var sql = "select item_id, item_type from item"
+              + " where item_type = 'P'"
+              + "   and item_id not in (select itemcost_item_id from itemcost);";
+      datasource.query(sql, creds, function (err, res) {
+        assert.isNull(err);
+        assert(res.rowCount > 0);
+        purItemId = res.rows[0].item_id;
+        console.log("Purchased: " + purItemId);
+        done();
+      });
+    });
+
+    it("should insert mfg item with valid cost elem but enforce PostStandardCosts priv", function (done) {
+      var sql = "select insertItemCost(" + mfgItemId
+              + ", costelem_id, basecurrid(), 1.23, TRUE) as result"
+              + " from costelem where costelem_type = 'Direct Labor';" ;
+      datasource.query(sql, creds, function (err, res) {
+        if (canPost) {
+          assert.isNull(err);
+          assert(res.rows[0].result > 0)
+        } else {
+          assert.isNotNull(err);
+          assert.match(err, /insertitemcost.*-7[^0-9]/i);
+        }
+        done();
+      });
+    });
+
+    it("should insert purchased item with valid cost elem but enforce PostStandardCosts priv", function (done) {
+      var sql = "select insertItemCost(" + purItemId
+              + ", costelem_id, basecurrid(), 1.23, TRUE) as result"
+              + " from costelem where costelem_type = 'Material';" ;
+      datasource.query(sql, creds, function (err, res) {
+        if (canPost) {
+          assert.isNull(err);
+          assert(res.rows[0].result > 0)
+        } else {
+          assert.isNotNull(err);
+          assert.match(err, /insertitemcost.*-7[^0-9]/i);
+        }
+        done();
+      });
+    });
+
+  });
+}());

--- a/test/database/functions/updateitemcost.sql
+++ b/test/database/functions/updateitemcost.sql
@@ -1,0 +1,88 @@
+var _ = require("underscore"),
+  assert = require('chai').assert,
+  path = require('path');
+
+(function () {
+  "use strict";
+  describe('updateItemCost()', function () {
+
+    var loginData = require(path.join(__dirname, "../../lib/login_data.js")).data,
+      datasource = require('../../../node-datasource/lib/ext/datasource').dataSource,
+      config = require(path.join(__dirname, "../../../node-datasource/config.js")),
+      creds = _.extend({}, config.databaseServer, {database: loginData.org}),
+      canPost = false,
+      itemcostRow;
+
+    it("should check if we have PostStandardCosts", function (done) {
+      var sql = "select checkPrivilege('PostStandardCosts') as result;";
+      datasource.query(sql, creds, function (err, res) {
+        assert.isNull(err);
+        canPost = res.rows[0].result;
+        done();
+      });
+    });
+
+    it("should complain if not found", function (done) {
+      var sql = "select updateItemCost(-1, NULL, NULL, NULL, NULL) as result;";
+      datasource.query(sql, creds, function (err, res) {
+        assert.isNotNull(err);
+        assert.match(err, /updateitemcost.*-3[^0-9]/i);
+        done();
+      });
+    });
+
+    it("should get an existing itemcost", function (done) {
+      var sql = "select * FROM itemcost where itemcost_actcost > 0 limit 1;";
+      datasource.query(sql, creds, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        itemcostRow = res.rows[0];
+        console.log(itemcostRow);
+        done();
+      });
+    });
+
+    it("should reject negative cost", function (done) {
+      var sql = "select updateItemCost("
+              + itemcostRow.itemcost_item_id + ","
+              + itemcostRow.itemcost_costelem_id
+              + ", -1, NULL, NULL) as result;";
+      datasource.query(sql, creds, function (err, res) {
+        assert.isNotNull(err);
+        assert.match(err, /updateitemcost.*-4[^0-9]/i);
+        done();
+      });
+    });
+
+    it("should reject 0 cost", function (done) {
+      var sql = "select updateItemCost("
+              + itemcostRow.itemcost_item_id + ","
+              + itemcostRow.itemcost_costelem_id
+              + ", 0, NULL, NULL) as result;";
+      datasource.query(sql, creds, function (err, res) {
+        assert.isNotNull(err);
+        assert.match(err, /updateitemcost.*-4[^0-9]/i);
+        done();
+      });
+    });
+
+    it("should update an itemcost but enforce PostStandardCosts priv", function (done) {
+      var sql = "select updateItemCost(" + itemcostRow.itemcost_item_id
+              + ", " + itemcostRow.itemcost_costelem_id 
+              + ", " + itemcostRow.itemcost_curr_id
+              + ", " + (itemcostRow.itemcost_actcost * 2)
+              + ", TRUE) as result";
+      datasource.query(sql, creds, function (err, res) {
+        if (canPost) {
+          assert.isNull(err);
+          assert(res.rows[0].result > 0)
+        } else {
+          assert.isNotNull(err);
+          assert.match(err, /updateitemcost.*-5[^0-9]/i);
+        }
+        done();
+      });
+    });
+
+  });
+}());

--- a/test/database/views/creditmemoline.js
+++ b/test/database/views/creditmemoline.js
@@ -1,0 +1,130 @@
+var _ = require("underscore"),
+  assert = require('chai').assert,
+  path = require('path');
+
+(function () {
+  "use strict";
+  describe('api.creditmemoline view', function () {
+
+    var loginData = require(path.join(__dirname, "../../lib/login_data.js")).data,
+      datasource = require('../../../node-datasource/lib/ext/datasource').dataSource,
+      config = require(path.join(__dirname, "../../../node-datasource/config.js")),
+      creds = _.extend({}, config.databaseServer, {database: loginData.org});
+
+    function creditmemoline(obj) {
+      return "ROW('" + obj.memo_number        + "',"
+               + (obj.line_number ?       obj.line_number        + ","  : "1,")
+               + (obj.item_number ? "'" + obj.item_number        + "'," : "NULL,")
+               + (obj.recv_site   ? "'" + obj.recv_site          + "'," : "'WH1',")
+               + (obj.reason_code ? "'" + obj.reason_code        + "'," : "NULL,")
+               + (obj.qty_returned ?      obj.qty_returned       + ","  : "0,")
+               + (obj.qty_to_credit ?     obj.qty_to_credit      + ","  : "0,")
+               + (obj.qty_uom     ? "'" + obj.qty_uom            + "'," : "NULL,")
+               + (obj.net_unit_price ?    obj.net_unit_price     + ","  : "0,")
+               + (obj.price_uom   ? "'" + obj.price_uom          + "'," : "NULL,")
+               + (obj.tax_type    ? "'" + obj.tax_type           + "'," : "NULL,")
+               + (obj.notes       ? "'" + obj.notes              + "'"  : "NULL")
+               + ")"
+               ;
+    }
+
+    it("should reject empty input on insert", function (done) {
+      var sql = "select insertcreditmemoline() as result;";
+      datasource.query(sql, creds, function (err, res) {
+        assert.isNotNull(err);
+        done();
+      });
+    });
+
+    it("should reject insert for non-existent credit memo", function (done) {
+      var line = creditmemoline({memo_number: 'non-existent'}),
+          sql  = "select insertcreditmemoline(%) as result;".replace(/%/g, line)
+        ;
+      datasource.query(sql, creds, function (err, res) {
+        assert.isNotNull(err);
+        assert.match(err, /xtuple:.*-1[^0-9]|not found/i);
+        done();
+      });
+    });
+
+    it("should allow creating a new credit memo", function (done) {
+      var memo = "ROW('99999', NULL, NULL, NULL, NULL, 0,"
+               +      "NULL, NULL, FALSE, 'TTOYS',"
+               +      "NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,"
+               +      "NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,"
+               +      "NULL, 'credit memo notes', 'USD', NULL, NULL,"
+               +      "NULL, 1)",
+          sql  = "select insertcreditmemo(%) as result;".replace(/%/g, memo)
+                 ;
+      datasource.query(sql, creds, function (err, res) {
+        assert.isNull(err);
+        assert.isTrue(res.rows[0].result);
+        done();
+      });
+    });
+
+    it("should accept insert for existing credit memo", function (done) {
+      var line = creditmemoline({memo_number: '99999',
+                                 line_number: 1,
+                                 item_number: 'YTRUCK1',
+                                 reason_code: 'SO-DAMAGED-RETURNED',
+                                 qty_to_credit: 5
+                                }),
+          sql  = "select insertcreditmemoline(%) as result;".replace(/%/g, line)
+        ;
+      datasource.query(sql, creds, function (err, res) {
+        assert.isNull(err);
+        assert.isTrue(res.rows[0].result);
+        done();
+      });
+    });
+
+    it("should reject update of non-existent memo", function (done) {
+      var line = creditmemoline({memo_number: 'non-existent'}),
+          sql  = "select updatecreditmemoline(%, %) as result;".replace(/%/g, line)
+        ;
+      datasource.query(sql, creds, function (err, res) {
+        assert.isNotNull(err);
+        done();
+      });
+    });
+
+    it("should reject update of non-existent credit memo line", function (done) {
+      var line = creditmemoline({memo_number: '99999',
+                                 line_number: 5,
+                                 item_number: 'YTRUCK1',
+                                 reason_code: 'SO-DAMAGED-RETURNED',
+                                 qty_to_credit: 5
+                                }),
+          sql  = "select updatecreditmemoline(%, %) as result;".replace(/%/g, line)
+        ;
+      datasource.query(sql, creds, function (err, res) {
+        assert.isNotNull(err);
+        assert.match(err, /xtuple:.*-1[^0-9]|not found/i);
+        done();
+      });
+    });
+
+    it("should accept update of existent credit memo line", function (done) {
+      var line = creditmemoline({memo_number: '99999',
+                                 line_number: 1,
+                                 item_number: 'YTRUCK1',
+                                 reason_code: 'SO-DAMAGED-RETURNED',
+                                 qty_to_credit: 1
+                                }),
+          sql  = "select updatecreditmemoline(%, %) as result;".replace(/%/g, line)
+        ;
+      datasource.query(sql, creds, function (err, res) {
+        assert.isNull(err);
+        assert.isTrue(res.rows[0].result);
+        done();
+      });
+    });
+
+    after(function (done) {
+      var sql = "delete from api.creditmemo where memo_number = '99999';";
+      datasource.query(sql, creds, done);
+    });
+  });
+
+}());


### PR DESCRIPTION
9.5 complained about mismatches between the number of `%` and the number of arguments passed to a `RAISE` statement. Added a couple of tests and removed some dead code.