### PR TITLE
Issue #25038 Fixed double-billing issue for kits and odd behavior when recalling a kit to shipping

### DIFF
--- a/foundation-database/public/functions/recallshipment.sql
+++ b/foundation-database/public/functions/recallshipment.sql
@@ -167,8 +167,7 @@ BEGIN
                      AND (sub.coitem_subnumber > 0)
                    GROUP BY cobill_id, cobill_qty
     LOOP
-      UPDATE cobill SET cobill_qty = 0.0
-      WHERE (cobill_id=_cobill.cobill_id);
+      DELETE FROM cobill WHERE cobill_id = _cobill.cobill_id;
     END LOOP;
 
   ELSEIF (_shiphead.shiphead_order_type = 'TO') THEN


### PR DESCRIPTION
Made the recallshipment function delete the cobill for kits instead of zero them out.  In selectuninvoicedshipment, for the case of kits, the update to a cobill is apparently non-additive whereas for other items it is additive.  Captured this distinction and applied the corresponding update to the cobill.

It is a bit tricky to reproduce the issue to begin with.  I managed to do it with a sales order containing two KCAR1 kits (separate line items).  Here are the steps I took thereafter:

1. Issued the one kit (but not the other) to shipping, shipped, and selected for billing.
2. Created the invoice.
3. Recalled the order to shipping.
4. Shipped the same kit again, selected for billing as before.
5. Issued the second kit, shipped, and selected for billing.
6. Observed the duplication while looking at the billing selection.

These steps to reproduce, however, are confounded by several earlier attempts I had made that may or may not have had any influence on the test.  I tried various issues and recalls before splitting into multiple shipments.

What I finally determined was that the cobill_qty was being updated in an additive manner for kits when selecting for billing, just like any other items.  In the case where an update occurred and the kit qty was already equal to coitem_qty, the resulting qty became twice the coitem_qty.  The additive update appears to be correct for shipped items, but as kits have no ship items, it would appear they are always billed by coitem quantity, not as a running total.

While working on this issue, I also observed a related defect where a cobill line was created for a kit.  After recalling the shipment, the cobill line still existed with qty 0.  The next time, when I issued the other kit, this 0 qty cobill showed up on the billing selection screen even though none of its components had been issued to shipping.  I resolved this issue by making recallshipment delete the cobill lines for kits rather than zero them out.  I don't know if this will have any other undesired side effects, but I did not observe any during my unit testing.

Finally, I was never able to reproduce a case where a non-kit item was duplicated during billing.