### PR TITLE
Issue #26756: Void Posted Checks in alternate bank account currency 

### DIFF
--- a/foundation-database/public/functions/voidpostedcheck.sql
+++ b/foundation-database/public/functions/voidpostedcheck.sql
@@ -126,8 +126,8 @@ BEGIN
                                           checkitem_amount * -1.0
                                      ELSE checkitem_amount END,
                                   _p.checkhead_checkdate) AS amount_check,
-                     apopen_id, apopen_doctype, apopen_docnumber, apopen_curr_rate, apopen_docdate,
-                     aropen_id, aropen_doctype, aropen_docnumber,
+                     apopen_id, apopen_doctype, apopen_docnumber, apopen_curr_id, apopen_curr_rate,
+                     apopen_docdate, aropen_id, aropen_doctype, aropen_docnumber,
                      checkitem_curr_id, checkitem_curr_rate,
                      COALESCE(checkitem_docdate, _p.checkhead_checkdate) AS docdate
               FROM (checkitem LEFT OUTER JOIN
@@ -239,16 +239,15 @@ BEGIN
             _exchGainTmp := ((_r.checkitem_amount / _r.apopen_curr_rate) - (_r.checkitem_amount/_p.checkhead_curr_rate));
           END IF;
         ELSE
-          -- unusual condition where bank overridden and different currency from voucher
-          -- [#26756] Following section was commented out but was causing problems.  Could not find
-          -- history about the comment below:
-          -- this does not work for all situations
           IF (_r.apopen_docdate > _p.checkhead_checkdate) THEN
             _exchGainTmp := ((_r.checkitem_amount/_r.checkitem_curr_rate) - (_r.checkitem_amount / _r.apopen_curr_rate)) * -1;
           ELSE
-            _exchGainTmp := ((_r.checkitem_amount / _r.apopen_curr_rate) - (_r.checkitem_amount/_r.checkitem_curr_rate));
+            IF (_p.checkhead_curr_id <> basecurrid() AND _r.apopen_curr_id <> basecurrid()) THEN 
+              _exchGainTmp := 0;
+            ELSE  
+              _exchGainTmp := ((_r.checkitem_amount / _r.apopen_curr_rate) - (_r.checkitem_amount/_r.checkitem_curr_rate));
+            END IF;
           END IF;
-          --_exchGainTmp := 0.0;
         END IF;
       ELSE
         SELECT arCurrGain(_r.aropen_id,_r.checkitem_curr_id, _r.checkitem_amount,

--- a/foundation-database/public/functions/voidpostedcheck.sql
+++ b/foundation-database/public/functions/voidpostedcheck.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE FUNCTION voidPostedCheck(INTEGER, INTEGER, DATE) RETURNS INTEGER AS $$
--- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple. 
+-- Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple. 
 -- See www.xtuple.com/CPAL for the full text of the software license.
 DECLARE
   pCheckid		ALIAS FOR $1;
@@ -240,13 +240,15 @@ BEGIN
           END IF;
         ELSE
           -- unusual condition where bank overridden and different currency from voucher
+          -- [#26756] Following section was commented out but was causing problems.  Could not find
+          -- history about the comment below:
           -- this does not work for all situations
-          --IF (_r.apopen_docdate > _p.checkhead_checkdate) THEN
-          --  _exchGainTmp := ((_r.checkitem_amount/_r.checkitem_curr_rate) - (_r.checkitem_amount / _r.apopen_curr_rate)) * -1;
-          --ELSE
-          --  _exchGainTmp := ((_r.checkitem_amount / _r.apopen_curr_rate) - (_r.checkitem_amount/_r.checkitem_curr_rate));
-          --END IF;
-          _exchGainTmp := 0.0;
+          IF (_r.apopen_docdate > _p.checkhead_checkdate) THEN
+            _exchGainTmp := ((_r.checkitem_amount/_r.checkitem_curr_rate) - (_r.checkitem_amount / _r.apopen_curr_rate)) * -1;
+          ELSE
+            _exchGainTmp := ((_r.checkitem_amount / _r.apopen_curr_rate) - (_r.checkitem_amount/_r.checkitem_curr_rate));
+          END IF;
+          --_exchGainTmp := 0.0;
         END IF;
       ELSE
         SELECT arCurrGain(_r.aropen_id,_r.checkitem_curr_id, _r.checkitem_amount,


### PR DESCRIPTION
Void Posted Checks in alternate bank account currency and dates.

For some reason this section of code was commented out with a statement "it does not work in all situations"  however commenting out the code was the cause of the issue #26756.

Unfortunately there is no history of this commenting out in Github so I cannot find the reasons behind it.  Is there a way to check prior history?