### PR TITLE
Issue #27383: Currency Gain/Loss incorrect when posting payments

### DIFF
--- a/foundation-database/public/functions/postcheck.sql
+++ b/foundation-database/public/functions/postcheck.sql
@@ -236,6 +236,10 @@ BEGIN
                         _p.checkhead_checkdate)
               INTO _exchGainTmp;
       END IF;
+
+      IF (_r.apopen_doctype = 'C') THEN
+        _exchGainTmp = _exchGainTmp * -1;
+      END IF; 
       _exchGain := _exchGain + _exchGainTmp;
 
       PERFORM insertIntoGLSeries( _sequence, _t.checkrecip_gltrans_source,


### PR DESCRIPTION
Could not post Payments where the exchange rate changed between posting the source document and the payment itself.  

Only affects Credit Memos - this fixes the exchange gain/loss calculation.