### PR TITLE
Fix XT.Debug() length cut off

### DIFF
--- a/foundation-database/manifest.js
+++ b/foundation-database/manifest.js
@@ -20,6 +20,9 @@
     "../lib/orm/source/create_plv8.sql",
     "../lib/orm/source/xt/functions/create_view.sql",
     "../lib/orm/source/xt/functions/install_js.sql",
+    "../lib/orm/source/xt/functions/raise_debug.sql",
+    "../lib/orm/source/xt/functions/raise_exception.sql",
+    "../lib/orm/source/xt/functions/raise_warning.sql",
 
     "../lib/orm/source/xt/functions/js_init.sql",
     "../lib/orm/source/reset_search_path.sql",

--- a/lib/orm/source/manifest.js
+++ b/lib/orm/source/manifest.js
@@ -28,7 +28,6 @@
     "xt/functions/not_any_text.sql",
     "xt/functions/post.sql",
     "xt/functions/patch.sql",
-    "xt/functions/raise_exception.sql",
     "xt/functions/retrieve_record.sql",
     "xt/functions/schema.sql",
     "xt/functions/set_dictionary.sql",

--- a/lib/orm/source/xt/functions/js_init.sql
+++ b/lib/orm/source/xt/functions/js_init.sql
@@ -289,8 +289,7 @@ return (function () {
 
     // TODO, this could be changed to "LOG" and you would need to set: client_min_messages = log
     // Then you would not get any of the "RAISE DEBUG;" messages from the PL/pgSQL code.
-    /* Do a hard trim to 900 so something prints. */
-    plv8.elog(DEBUG1, (msg + message).substring(0, 900));
+    plv8.execute('SELECT xt.raise_debug($1)', [msg + message]);
   }
 
   /**

--- a/lib/orm/source/xt/functions/raise_debug.sql
+++ b/lib/orm/source/xt/functions/raise_debug.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE FUNCTION xt.raise_debug(message text) RETURNS void AS $$
+BEGIN
+
+  RAISE DEBUG '%', message;
+
+END;
+$$ LANGUAGE 'plpgsql';

--- a/lib/orm/source/xt/functions/raise_warning.sql
+++ b/lib/orm/source/xt/functions/raise_warning.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE FUNCTION xt.raise_warning(message text) RETURNS void AS $$
+BEGIN
+
+  RAISE WARNING '%', message;
+
+END;
+$$ LANGUAGE 'plpgsql';


### PR DESCRIPTION
plv8.elog() uses a C++ char with a hard limit of 1024 chars. This cuts off long `XT.Debug()` messages. Switch to use `RAISE DEBUG`, which is straight Postgres and has no limit.