### PR TITLE
issue #27692 - Properly handle inventory history for work orders

### DIFF
--- a/foundation-database/public/functions/issuewomaterial.sql
+++ b/foundation-database/public/functions/issuewomaterial.sql
@@ -73,15 +73,15 @@ BEGIN
 END;
 $$ LANGUAGE 'plpgsql';
 
-CREATE OR REPLACE FUNCTION issueWoMaterial(INTEGER, NUMERIC, INTEGER, TIMESTAMP WITH TIME ZONE) RETURNS INTEGER AS $$
+CREATE OR REPLACE FUNCTION issueWoMaterial(INTEGER, NUMERIC, INTEGER, TIMESTAMP WITH TIME ZONE, NUMERIC) RETURNS INTEGER AS $$
 -- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple. 
 -- See www.xtuple.com/CPAL for the full text of the software license.
 BEGIN
-  RETURN issueWoMaterial($1, $2, $3, $4, NULL);
+  RETURN issueWoMaterial($1, $2, $3, $4, NULL, $5);
 END;
 $$ LANGUAGE 'plpgsql';
 
-CREATE OR REPLACE FUNCTION issueWoMaterial(INTEGER, NUMERIC, INTEGER, TIMESTAMP WITH TIME ZONE, INTEGER) RETURNS INTEGER AS $$
+CREATE OR REPLACE FUNCTION issueWoMaterial(INTEGER, NUMERIC, INTEGER, TIMESTAMP WITH TIME ZONE, INTEGER, NUMERIC) RETURNS INTEGER AS $$
 -- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple. 
 -- See www.xtuple.com/CPAL for the full text of the software license.
 DECLARE
@@ -90,6 +90,7 @@ DECLARE
   pItemlocSeries ALIAS FOR $3;
   pGlDistTS ALIAS FOR $4;
   pInvhistid ALIAS FOR $5;
+  pPrevQty ALIAS FOR $6;
   _p RECORD;
   _invhistid INTEGER;
   _itemlocSeries INTEGER;
@@ -124,7 +125,7 @@ BEGIN
   ELSE
     SELECT NEXTVAL('itemloc_series_seq') INTO _itemlocSeries;
   END IF;
-  SELECT postInvTrans( ci.itemsite_id, 'IM', _p.qty,
+  SELECT postInvTrans( pPrevQty, ci.itemsite_id, 'IM', _p.qty,
                       'W/O', 'WO', _p.woNumber, '',
                       ('Material ' || item_number || ' Issue to Work Order'),
                       getPrjAccntId(_p.wo_prj_id, pc.costcat_wip_accnt_id),

--- a/foundation-database/public/functions/issuewomaterial.sql
+++ b/foundation-database/public/functions/issuewomaterial.sql
@@ -132,7 +132,7 @@ BEGIN
                       ('Material ' || item_number || ' Issue to Work Order'),
                       getPrjAccntId(_p.wo_prj_id, pc.costcat_wip_accnt_id),
                       cc.costcat_asset_accnt_id, _itemlocSeries, pGlDistTS,
-                      NULL, pPrevQty, pInvhistid ) INTO _invhistid
+                      NULL, pInvhistid, pPrevQty ) INTO _invhistid
   FROM itemsite AS ci, itemsite AS pi,
        costcat AS cc, costcat AS pc,
        item

--- a/foundation-database/public/functions/issuewomaterial.sql
+++ b/foundation-database/public/functions/issuewomaterial.sql
@@ -73,7 +73,8 @@ BEGIN
 END;
 $$ LANGUAGE 'plpgsql';
 
-CREATE OR REPLACE FUNCTION issueWoMaterial(INTEGER, NUMERIC, INTEGER, TIMESTAMP WITH TIME ZONE, NUMERIC) RETURNS INTEGER AS $$
+DROP FUNCTION IF EXISTS issueWoMaterial(INTEGER, NUMERIC, INTEGER, TIMESTAMP WITH TIME ZONE);
+CREATE OR REPLACE FUNCTION issueWoMaterial(INTEGER, NUMERIC, INTEGER, TIMESTAMP WITH TIME ZONE, NUMERIC DEFAULT NULL) RETURNS INTEGER AS $$
 -- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple. 
 -- See www.xtuple.com/CPAL for the full text of the software license.
 BEGIN
@@ -81,7 +82,8 @@ BEGIN
 END;
 $$ LANGUAGE 'plpgsql';
 
-CREATE OR REPLACE FUNCTION issueWoMaterial(INTEGER, NUMERIC, INTEGER, TIMESTAMP WITH TIME ZONE, INTEGER, NUMERIC) RETURNS INTEGER AS $$
+DROP FUNCTION IF EXISTS issueWoMaterial(INTEGER, NUMERIC, INTEGER, TIMESTAMP WITH TIME ZONE, INTEGER);
+CREATE OR REPLACE FUNCTION issueWoMaterial(INTEGER, NUMERIC, INTEGER, TIMESTAMP WITH TIME ZONE, INTEGER, NUMERIC DEFAULT NULL) RETURNS INTEGER AS $$
 -- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple. 
 -- See www.xtuple.com/CPAL for the full text of the software license.
 DECLARE
@@ -125,12 +127,12 @@ BEGIN
   ELSE
     SELECT NEXTVAL('itemloc_series_seq') INTO _itemlocSeries;
   END IF;
-  SELECT postInvTrans( pPrevQty, ci.itemsite_id, 'IM', _p.qty,
+  SELECT postInvTrans( ci.itemsite_id, 'IM', _p.qty,
                       'W/O', 'WO', _p.woNumber, '',
                       ('Material ' || item_number || ' Issue to Work Order'),
                       getPrjAccntId(_p.wo_prj_id, pc.costcat_wip_accnt_id),
                       cc.costcat_asset_accnt_id, _itemlocSeries, pGlDistTS,
-                      NULL, pInvhistid ) INTO _invhistid
+                      NULL, pPrevQty, pInvhistid ) INTO _invhistid
   FROM itemsite AS ci, itemsite AS pi,
        costcat AS cc, costcat AS pc,
        item

--- a/foundation-database/public/functions/postinvtrans.sql
+++ b/foundation-database/public/functions/postinvtrans.sql
@@ -13,8 +13,8 @@ CREATE OR REPLACE FUNCTION postInvTrans(pItemsiteId    INTEGER,
                                         pTimestamp     TIMESTAMP WITH TIME ZONE
                                                        DEFAULT CURRENT_TIMESTAMP,
                                         pCostOvrld     NUMERIC DEFAULT NULL,
-                                        pPrevQty       NUMERIC DEFAULT NULL,
-                                        pInvhistid     INTEGER DEFAULT NULL)
+                                        pInvhistid     INTEGER DEFAULT NULL,
+                                        pPrevQty       NUMERIC DEFAULT NULL)
   RETURNS INTEGER AS $$
 -- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple. 
 -- See www.xtuple.com/CPAL for the full text of the software license.
@@ -125,8 +125,8 @@ BEGIN
       invhist_series )
   SELECT
     _invhistid, itemsite_id, pTransType, _timestamp,
-    pQty, (itemsite_qtyonhand + (_sense * pPrevQty)),
-    (itemsite_qtyonhand + (_sense * pQty) + (_sense * pPrevQty)),
+    pQty, (itemsite_qtyonhand + (_sense * COALESCE(pPrevQty, 0.0))),
+    (itemsite_qtyonhand + (_sense * pQty) + (_sense * COALESCE(pPrevQty, 0.0))),
     itemsite_costmethod, itemsite_value,
     -- sanity check to ensure that value = 0 when qtyonhand = 0
     CASE WHEN ((itemsite_qtyonhand + (_sense * pQty))) = 0.0 THEN 0.0

--- a/foundation-database/public/functions/postinvtrans.sql
+++ b/foundation-database/public/functions/postinvtrans.sql
@@ -1,5 +1,5 @@
-CREATE OR REPLACE FUNCTION postInvTrans(pPrevQty       NUMERIC,
-                                        pItemsiteId    INTEGER,
+DROP FUNCTION IF EXISTS postInvTrans(INTEGER, TEXT, NUMERIC, TEXT, TEXT, TEXT, TEXT, TEXT, INTEGER, INTEGER, INTEGER, TIMESTAMP WITH TIME ZONE, NUMERIC, INTEGER);
+CREATE OR REPLACE FUNCTION postInvTrans(pItemsiteId    INTEGER,
                                         pTransType     TEXT,
                                         pQty           NUMERIC,
                                         pModule        TEXT,
@@ -13,6 +13,7 @@ CREATE OR REPLACE FUNCTION postInvTrans(pPrevQty       NUMERIC,
                                         pTimestamp     TIMESTAMP WITH TIME ZONE
                                                        DEFAULT CURRENT_TIMESTAMP,
                                         pCostOvrld     NUMERIC DEFAULT NULL,
+                                        pPrevQty       NUMERIC DEFAULT NULL,
                                         pInvhistid     INTEGER DEFAULT NULL)
   RETURNS INTEGER AS $$
 -- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple. 

--- a/foundation-database/public/functions/postinvtrans.sql
+++ b/foundation-database/public/functions/postinvtrans.sql
@@ -1,4 +1,5 @@
-CREATE OR REPLACE FUNCTION postInvTrans(pItemsiteId    INTEGER,
+CREATE OR REPLACE FUNCTION postInvTrans(pPrevQty       NUMERIC,
+                                        pItemsiteId    INTEGER,
                                         pTransType     TEXT,
                                         pQty           NUMERIC,
                                         pModule        TEXT,
@@ -123,8 +124,8 @@ BEGIN
       invhist_series )
   SELECT
     _invhistid, itemsite_id, pTransType, _timestamp,
-    pQty, itemsite_qtyonhand,
-    (itemsite_qtyonhand + (_sense * pQty)),
+    pQty, (itemsite_qtyonhand + (_sense * pPrevQty)),
+    (itemsite_qtyonhand + (_sense * pQty) + (_sense * pPrevQty)),
     itemsite_costmethod, itemsite_value,
     -- sanity check to ensure that value = 0 when qtyonhand = 0
     CASE WHEN ((itemsite_qtyonhand + (_sense * pQty))) = 0.0 THEN 0.0

--- a/foundation-database/public/functions/postproduction.sql
+++ b/foundation-database/public/functions/postproduction.sql
@@ -157,7 +157,7 @@ BEGIN
                        'W/O', 'WO', _woNumber, '', ('Receive Inventory ' || item_number || ' ' || _sense || ' Manufacturing'),
                        costcat_asset_accnt_id, getPrjAccntId(wo_prj_id, costcat_wip_accnt_id), _itemlocSeries, pGlDistTS,
                        -- the following is only actually used when the item is average or job costed
-                       _wipPost, 0.0 ) INTO _invhistid
+                       _wipPost, NULL, 0.0 ) INTO _invhistid
   FROM wo, itemsite, item, costcat
   WHERE ( (wo_itemsite_id=itemsite_id)
    AND (itemsite_item_id=item_id)

--- a/foundation-database/public/functions/postproduction.sql
+++ b/foundation-database/public/functions/postproduction.sql
@@ -27,6 +27,8 @@ DECLARE
   _wipPost       NUMERIC;
   _woNumber      TEXT;
   _ucost         NUMERIC;
+  _prevItemsite  INTEGER;
+  _prevQty       NUMERIC;
 
 BEGIN
 
@@ -83,7 +85,9 @@ BEGIN
   END IF;
 
   IF (pBackflush) THEN
-    FOR _r IN SELECT womatl_id, womatl_qtyiss +
+    _prevItemsite := 0;
+    _prevQty := 0.0;
+    FOR _r IN SELECT itemsite_id, womatl_id, womatl_qtyiss +
 		     (CASE
 		       WHEN (womatl_qtywipscrap >  ((womatl_qtyfxd + (_parentQty + wo_qtyrcv) * womatl_qtyper) * womatl_scrap)) THEN
                          (womatl_qtyfxd + (_parentQty + wo_qtyrcv) * womatl_qtyper) * womatl_scrap
@@ -100,7 +104,12 @@ BEGIN
       -- Don't issue more than should have already been consumed at this point
       IF (pQty > 0) THEN
         IF (noNeg(_r.expected - _r.consumed) > 0) THEN
-          SELECT issueWoMaterial(_r.womatl_id, noNeg(_r.expected - _r.consumed), _itemlocSeries, pGlDistTS) INTO _itemlocSeries;
+          IF (_r.itemsite_id != _prevItemsite) THEN
+            _prevQty := 0.0;
+          END IF;
+          SELECT issueWoMaterial(_r.womatl_id, noNeg(_r.expected - _r.consumed), _itemlocSeries, pGlDistTS, _prevQty) INTO _itemlocSeries;
+          _prevItemsite := _r.itemsite_id;
+          _prevQty := _prevQty+noNeg(_r.expected - _r.consumed);
         END IF;
       ELSE
         -- Used by postMiscProduction of disassembly
@@ -144,7 +153,7 @@ BEGIN
     JOIN itemsite ON (wo_itemsite_id=itemsite_id)
   WHERE (wo_id=pWoid);
 
-  SELECT postInvTrans( itemsite_id, 'RM', _parentQty,
+  SELECT postInvTrans( 0.0, itemsite_id, 'RM', _parentQty,
                        'W/O', 'WO', _woNumber, '', ('Receive Inventory ' || item_number || ' ' || _sense || ' Manufacturing'),
                        costcat_asset_accnt_id, getPrjAccntId(wo_prj_id, costcat_wip_accnt_id), _itemlocSeries, pGlDistTS,
                        -- the following is only actually used when the item is average or job costed

--- a/foundation-database/public/functions/postproduction.sql
+++ b/foundation-database/public/functions/postproduction.sql
@@ -153,11 +153,11 @@ BEGIN
     JOIN itemsite ON (wo_itemsite_id=itemsite_id)
   WHERE (wo_id=pWoid);
 
-  SELECT postInvTrans( 0.0, itemsite_id, 'RM', _parentQty,
+  SELECT postInvTrans( itemsite_id, 'RM', _parentQty,
                        'W/O', 'WO', _woNumber, '', ('Receive Inventory ' || item_number || ' ' || _sense || ' Manufacturing'),
                        costcat_asset_accnt_id, getPrjAccntId(wo_prj_id, costcat_wip_accnt_id), _itemlocSeries, pGlDistTS,
                        -- the following is only actually used when the item is average or job costed
-                       _wipPost ) INTO _invhistid
+                       _wipPost, 0.0 ) INTO _invhistid
   FROM wo, itemsite, item, costcat
   WHERE ( (wo_itemsite_id=itemsite_id)
    AND (itemsite_item_id=item_id)


### PR DESCRIPTION
For work orders with multiple instances of the same item, have the inventory history QOH before and after columns show the correct amounts.