### PR TITLE
issue #27840 - filter out the starting record

### DIFF
--- a/foundation-database/public/functions/_docinfo.sql
+++ b/foundation-database/public/functions/_docinfo.sql
@@ -84,7 +84,7 @@ BEGIN
                        target_doc_name,
                        target_doc_descrip,
                        _target.docass_purpose
-                  FROM _getTargetDocument(_target.docass_id, _target.source_id)
+                  FROM _getTargetDocument(_target.docass_id, _target.source_id, pRefId)
      LOOP
        RETURN NEXT _row;
     END LOOP;

--- a/foundation-database/public/functions/_gettargetdocument.sql
+++ b/foundation-database/public/functions/_gettargetdocument.sql
@@ -1,10 +1,12 @@
-﻿DROP FUNCTION IF EXISTS _gettargetdocument(INTEGER, INTEGER);
+DROP FUNCTION IF EXISTS _gettargetdocument(INTEGER, INTEGER);
 CREATE OR REPLACE FUNCTION _gettargetdocument(pDocAssId INTEGER,
                                               pSourceId INTEGER,
                                               pSourceDocId INTEGER = -1)
   RETURNS SETOF _targetdoc AS $$
+-- Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
+-- See www.xtuple.com/CPAL for the full text of the software license.
 DECLARE
-  _targetId INTEGER[];
+  _targetId INTEGER;
   _baseq    TEXT := NULL;
   _query    TEXT := NULL;
   _src      RECORD;
@@ -19,9 +21,9 @@ BEGIN
                     pSourceId;
   END IF;
 
-  SELECT CASE WHEN docass_source_type = docass_target_type THEN ARRAY[docass_source_id, docass_target_id]
-              WHEN _src.source_docass = docass_target_type THEN ARRAY[docass_target_id]
-              ELSE ARRAY[docass_source_id]
+  SELECT CASE WHEN docass_source_type = _src.source_docass
+               AND docass_source_id = pSourceDocId THEN docass_target_id
+              ELSE docass_source_id
          END INTO _targetId
     FROM docass
    WHERE docass_id = pDocAssId;
@@ -39,15 +41,14 @@ BEGIN
                   %s AS target_doc_descrip
              FROM %s
              %s
-            WHERE %s IN (%s)
-              AND %s != %s;
+            WHERE %s = %s;
            $Q$;
 
   _query = format(_baseq, pDocAssId, pSourceId,
                   _src.source_number_field, _src.source_name_field,
                   _src.source_desc_field, _src.source_table,
                   coalesce(_src.source_joins, ''), _src.source_key_field,
-                  array_to_string(_targetId, ','), _src.source_key_field, pSourceDocId);
+                  _targetId);
   RAISE DEBUG '%', _query;
 
   FOR _row IN EXECUTE(_query)


### PR DESCRIPTION
The Documents tab in the desktop application was showing the wrong data when viewing the target record if source and targets had the same document type. This PR makes the query in `_getTargetDocument()` more precise, checking the source type and id instead of just the type.