### PR TITLE
Issue #27962 Add trigger to set shiptoinfo defaults if they aren't provided.

### DIFF
--- a/foundation-database/public/trigger_functions/shiptoinfo.sql
+++ b/foundation-database/public/trigger_functions/shiptoinfo.sql
@@ -1,5 +1,75 @@
+CREATE OR REPLACE FUNCTION _shiptoinfoBeforeTrigger () RETURNS TRIGGER AS $$
+-- Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
+-- See www.xtuple.com/CPAL for the full text of the software license.
+DECLARE
+  _SalesRepId INTEGER;
+  _SalesRepComm NUMERIC;
+  _ShipViaName TEXT;
+  _ShipFormId INTEGER;
+  _ShipChargeId INTEGER;
+  _PreferredWarehousId INTEGER;
+
+BEGIN
+  -- Set all the shiptoinfo defaults.
+
+  IF (NEW.shipto_salesrep_id IS NULL OR NEW.shipto_salesrep_id < 1) THEN
+    _SalesRepId = fetchmetricvalue('DefaultSalesRep');
+    IF (_SalesRepId IS NOT NULL) THEN
+      NEW.shipto_salesrep_id = _SalesRepId;
+    END IF;
+  END IF;
+
+  IF (NEW.shipto_commission IS NULL OR NEW.shipto_commission < 0) THEN
+    IF (NEW.shipto_salesrep_id IS NOT NULL) THEN
+      _SalesRepId = NEW.shipto_salesrep_id;
+    ELSE
+      _SalesRepId = fetchmetricvalue('DefaultSalesRep');
+    END IF;
+
+    IF (_SalesRepId IS NOT NULL) THEN
+      SELECT salesrep_commission INTO _SalesRepComm FROM salesrep WHERE salesrep_id = _SalesRepId;
+      NEW.shipto_commission = _SalesRepComm;
+    END IF;
+  END IF;
+
+  IF (NEW.shipto_shipvia IS NULL OR NEW.shipto_shipvia = '') THEN
+    SELECT shipvia_code INTO _ShipViaName FROM shipvia WHERE shipvia_id = fetchmetricvalue('DefaultShipViaId');
+    IF (_ShipViaName IS NOT NULL) THEN
+      NEW.shipto_shipvia = _ShipViaName;
+    END IF;
+  END IF;
+
+  IF (NEW.shipto_shipform_id IS NULL OR NEW.shipto_shipform_id < 1) THEN
+    _ShipFormId = fetchmetricvalue('DefaultShipFormId');
+    IF (_ShipFormId IS NOT NULL) THEN
+      NEW.shipto_shipform_id = _ShipFormId;
+    END IF;
+  END IF;
+
+  IF (NEW.shipto_shipchrg_id IS NULL OR NEW.shipto_shipchrg_id < 1) THEN
+    _ShipChargeId = fetchmetricvalue('DefaultShipChrgId');
+    IF (_ShipChargeId IS NOT NULL) THEN
+      NEW.shipto_shipchrg_id = _ShipChargeId;
+    END IF;
+  END IF;
+
+  IF (NEW.shipto_preferred_warehous_id IS NULL OR NEW.shipto_preferred_warehous_id < 1) THEN
+    _PreferredWarehousId = fetchmetricvalue('DefaultSellingWarehouseId');
+    IF (_PreferredWarehousId IS NOT NULL) THEN
+      NEW.shipto_preferred_warehous_id = _PreferredWarehousId;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE 'plpgsql';
+
+DROP TRIGGER IF EXISTS shiptoinfoBeforeTrigger ON shiptoinfo;
+CREATE TRIGGER shiptoinfoBeforeTrigger BEFORE INSERT OR UPDATE ON shiptoinfo FOR EACH ROW EXECUTE PROCEDURE _shiptoinfoBeforeTrigger();
+
+
 CREATE OR REPLACE FUNCTION _shiptoinfoAfterTrigger () RETURNS TRIGGER AS $$
--- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+-- Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
 DECLARE
   _cmnttypeid INTEGER;
@@ -76,4 +146,3 @@ $$ LANGUAGE 'plpgsql';
 
 DROP TRIGGER IF EXISTS shiptoinfoAfterTrigger ON shiptoinfo;
 CREATE TRIGGER shiptoinfoAfterTrigger AFTER INSERT OR UPDATE ON shiptoinfo FOR EACH ROW EXECUTE PROCEDURE _shiptoinfoAfterTrigger();
-


### PR DESCRIPTION
We added default configs for these to `Sales > Setup > Customer Defaults` a while ago. The PR uses those metrics to set defaults.