### PR TITLE
issue #24866 Fixed copy/paste error.

### DIFF
--- a/foundation-database/public/patches/populate_source.sql
+++ b/foundation-database/public/patches/populate_source.sql
@@ -460,7 +460,7 @@ select createDoctype(27, --pDocAssNum
                      '', --pWidget
                      'join custinfo on rahead_cust_id = cust_id', --pJoin
                      'rahead_id', --pParam
-                     'purchaseOrder', --pUi
+                     'returnAuthorization', --pUi
                      '', --pPriv
                      'Sales' --pModule
 );


### PR DESCRIPTION
Error was resulting in the widget for a return authorization being paired with the purchaseOrder screen.  Now associating with the returnAuthorization screen.

NOTE: This pull request is paired with a corresponding pull request in private-extensions.