### PR TITLE
issue #28348 - add optional active flag field to source table

### DIFF
--- a/foundation-database/public/functions/createdoctype.sql
+++ b/foundation-database/public/functions/createdoctype.sql
@@ -6,9 +6,10 @@ create or replace function createDoctype(pDocAssNum integer, pType text, pDocAss
                                          pDesc    text,
                                          pWidget  text = '', pJoin   text = '',
                                          pParam   text = '', pUi     text = '',
-                                         pPriv    text = '', pModule text = 'System')
+                                         pPriv    text = '', pModule text = 'System',
+                                         pActive  text = '')
   returns integer as $$
-/* Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple.
+/* Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
    See www.xtuple.com/CPAL for the full text of the software license.
 
    Create a record in the "source" table corresponding to this document type
@@ -21,43 +22,43 @@ create or replace function createDoctype(pDocAssNum integer, pType text, pDocAss
 declare
   _id integer := -1;
 begin
-  select source_id into _id
-    from source where source_name = pType
-    for update;
 
-  if not found then
+  update source
+     set source_docass_num   = coalesce(pDocAssNum, 0),
+         source_module       = pModule,
+         source_docass       = pDocAss,
+         source_charass      = pCharass,
+         source_descrip      = pFull,
+         source_table        = pTable,
+         source_key_field    = pKey,
+         source_number_field = pNumber,
+         source_name_field   = pName,
+         source_desc_field   = pDesc,
+         source_joins        = pJoin,
+         source_widget       = pWidget,
+         source_key_param    = pParam,
+         source_uiform_name  = pUi,
+         source_create_priv  = pPriv,
+         source_active_field = pActive
+   where source_name = pType
+   returning source_id into _id;
+
+  if _id is null then
     insert into source (source_docass_num, source_module,
         source_name,      source_descrip,      source_table,
         source_docass,    source_charass,
         source_key_field, source_number_field, source_name_field,
         source_desc_field, source_joins,       source_widget,
-        source_key_param, source_uiform_name,  source_create_priv
+        source_key_param, source_uiform_name,  source_create_priv,
+        source_active_field
       ) values (coalesce(pDocAssNum, 0), pModule,
          pType,   pFull,   pTable,
          pDocAss, pCharAss,
          pKey,    pNumber, pName,
          pDesc,   pJoin,   pWidget,
-         pParam,  pUi,     pPriv)
-      returning source_id into _id;
-  else
-    update source
-       set source_docass_num   = coalesce(pDocAssNum, 0),
-           source_module       = pModule,
-           source_docass       = pDocAss,
-           source_charass      = pCharass,
-           source_descrip      = pFull,
-           source_table        = pTable,
-           source_key_field    = pKey,
-           source_number_field = pNumber,
-           source_name_field   = pName,
-           source_desc_field   = pDesc,
-           source_joins        = pJoin,
-           source_widget       = pWidget,
-           source_key_param    = pParam,
-           source_uiform_name  = pUi,
-           source_create_priv  = pPriv
-     where source_name = pType
-     returning source_id into _id;
+         pParam,  pUi,     pPriv,
+         pActive
+      ) returning source_id into _id;
   end if;
 
   return _id;

--- a/foundation-database/public/patches/populate_source.sql
+++ b/foundation-database/public/patches/populate_source.sql
@@ -368,7 +368,7 @@ select createDoctype(21, --pDocAssNum
                      '', --pUi
                      '', --pPriv
                      'Inventory',       -- pModule
-                     'location_usable'  -- pActive
+                     'location_active'  -- pActive
 );
 select createDoctype(22, --pDocAssNum
                      'LS', --pType

--- a/foundation-database/public/patches/populate_source.sql
+++ b/foundation-database/public/patches/populate_source.sql
@@ -17,7 +17,8 @@ select createDoctype(1, --pDocAssNum
                      'addr_id', --pParam
                      '', --pUi
                      '', --pPriv
-                     'CRM' --pModule
+                     'CRM',             -- pModule
+                     'addr_active'      -- pActive
 );
 select createDoctype(2, --pDocAssNum
                      'BBH', --pType
@@ -136,7 +137,8 @@ select createDoctype(8, --pDocAssNum
                      'crmacct_id', --pParam
                      'crmaccount', --pUi
                      '', --pPriv
-                     'CRM' --pModule
+                     'CRM',             -- pModule
+                     'crmacct_active'   -- pActive
 );
 select createDoctype(9, --pDocAssNum
                      'T', --pType
@@ -153,7 +155,8 @@ select createDoctype(9, --pDocAssNum
                      'cntct_id', --pParam
                      'contact', --pUi
                      '', --pPriv
-                     'CRM' --pModule
+                     'CRM',             -- pModule
+                     'cntct_active'     -- pActive
 );
 select createDoctype(10, --pDocAssNum
                      'CNTR', --pType
@@ -222,7 +225,8 @@ select createDoctype(13, --pDocAssNum
                      'cust_id', --pParam
                      'customer', --pUi
                      '', --pPriv
-                     'Sales' --pModule
+                     'Sales',           -- pModule
+                     'cust_active'      -- pActive
 );
 select createDoctype(14, --pDocAssNum
                      'EMP', --pType
@@ -239,7 +243,8 @@ select createDoctype(14, --pDocAssNum
                      'emp_id', --pParam
                      'employee', --pUi
                      '', --pPriv
-                     'System' --pModule
+                     'System',          -- pModule
+                     'emp_active'       -- pActive
 );
 select createDoctype(15, --pDocAssNum
                      'INCDT', --pType
@@ -308,7 +313,8 @@ select createDoctype(18, --pDocAssNum
                      'item_id', --pParam
                      'item', --pUi
                      '', --pPriv
-                     'Products' --pModule
+                     'Products',        -- pModule
+                     'item_active'      -- pActive
 );
 select createDoctype(19, --pDocAssNum
                      'IS', --pType
@@ -325,7 +331,8 @@ select createDoctype(19, --pDocAssNum
                      '', --pParam
                      '', --pUi
                      '', --pPriv
-                     'Inventory' --pModule
+                     'Inventory',       -- pModule
+                     'itemsite_active'  -- pActive
 );
 select createDoctype(20, --pDocAssNum
                      'IR', --pType
@@ -342,7 +349,8 @@ select createDoctype(20, --pDocAssNum
                      'itemsrc_id', --pParam
                      'itemSource', --pUi
                      '', --pPriv
-                     'Purchase' --pModule
+                     'Purchase',        -- pModule
+                     'itemsrc_active'   -- pActive
 );
 select createDoctype(21, --pDocAssNum
                      'L', --pType
@@ -359,7 +367,8 @@ select createDoctype(21, --pDocAssNum
                      '', --pParam
                      '', --pUi
                      '', --pPriv
-                     'Inventory' --pModule
+                     'Inventory',       -- pModule
+                     'location_usable'  -- pActive
 );
 select createDoctype(22, --pDocAssNum
                      'LS', --pType
@@ -393,7 +402,8 @@ select createDoctype(23, --pDocAssNum
                      'ophead_id', --pParam
                      'opportunity', --pUi
                      'MaintainPersonalOpportunities MaintainAllOpportunities', --pPriv
-                     'CRM' --pModule
+                     'CRM',             -- pModule
+                     'ophead_active'    -- pActive
 );
 select createDoctype(24, --pDocAssNum
                      'J', --pType
@@ -557,7 +567,7 @@ select createDoctype(33, --pDocAssNum
                      'SHP', --pDocAss
                      '', --pCharAss
                      'Ship To', --pFull
-                     'shipto', --pTable
+                     'shiptoinfo', --pTable
                      'shipto_id', --pKey
                      'shipto_num', --pNumber
                      'cust_name', --pName
@@ -567,7 +577,8 @@ select createDoctype(33, --pDocAssNum
                      'shipto_id', --pParam
                      'shipTo', --pUi
                      '', --pPriv
-                     'Sales' --pModule
+                     'Sales',           --pModule
+                     'shipto_active'
 );
 select createDoctype(34, --pDocAssNum
                      'TE', --pType
@@ -601,7 +612,8 @@ select createDoctype(35, --pDocAssNum
                      'todoitem_id', --pParam
                      'todoItem', --pUi
                      'MaintainPersonalToDoItems MaintainAllToDoItems', --pPriv
-                     'CRM' --pModule
+                     'CRM',             -- pModule
+                     'todoitem_active'  -- pActive
 );
 select createDoctype(36, --pDocAssNum
                      'TO', --pType
@@ -652,7 +664,8 @@ select createDoctype(38, --pDocAssNum
                      'vend_id', --pParam
                      'vendor', --pUi
                      '', --pPriv
-                     'Purchase' --pModule
+                     'Purchase',        -- pModule
+                     'vend_active'      -- pActive
 );
 select createDoctype(39, --pDocAssNum
                      'VCH', --pType
@@ -686,7 +699,8 @@ select createDoctype(40, --pDocAssNum
                      '', --pParam
                      '', --pUi
                      '', --pPriv
-                     'Inventory' --pModule
+                     'Inventory',       -- pModule
+                     'warehous_active'  -- pActive
 );
 select createDoctype(41, --pDocAssNum
                      'W', --pType
@@ -737,7 +751,8 @@ select createDoctype(NULL, --pDocAssNum
                      '', --pParam
                      '', --pUi
                      '', --pPriv
-                     'CRM' --pModule
+                     'CRM',             -- pModule
+                     'prospect_active'  -- pActive
 );
 select createDoctype(NULL, --pDocAssNum
                      'SR', --pType
@@ -754,7 +769,8 @@ select createDoctype(NULL, --pDocAssNum
                      '', --pParam
                      '', --pUi
                      '', --pPriv
-                     'Sales' --pModule
+                     'Sales',           -- pModule
+                     'salesrep_active'  -- pActive
 );
 select createDoctype(NULL, --pDocAssNum
                      'TAXAUTH', --pType
@@ -788,7 +804,8 @@ select createDoctype(NULL, --pDocAssNum
                      '', --pParam
                      '', --pUi
                      '', --pPriv
-                     'System' --pModule
+                     'System',          -- pModule
+                     'usr_active'       -- pActive
 );
 select createDoctype(NULL, --pDocAssNum
                      'CT', --pType

--- a/foundation-database/public/tables/source.sql
+++ b/foundation-database/public/tables/source.sql
@@ -6,6 +6,7 @@ select xt.add_column('source', 'source_key_field',    'TEXT', $$NOT NULL DEFAULT
 select xt.add_column('source', 'source_number_field', 'TEXT', $$NOT NULL DEFAULT ''$$, 'public');
 select xt.add_column('source', 'source_name_field',   'TEXT', $$NOT NULL DEFAULT ''$$, 'public');
 select xt.add_column('source', 'source_desc_field',   'TEXT', $$NOT NULL DEFAULT ''$$, 'public');
+select xt.add_column('source', 'source_active_field', 'TEXT', $$NOT NULL DEFAULT ''$$, 'public');
 select xt.add_column('source', 'source_widget',       'TEXT', $$NOT NULL DEFAULT ''$$, 'public');
 select xt.add_column('source', 'source_joins',        'TEXT', $$NOT NULL DEFAULT ''$$, 'public');
 select xt.add_column('source', 'source_key_param',    'TEXT', $$NOT NULL DEFAULT ''$$, 'public');
@@ -26,6 +27,7 @@ COMMENT ON COLUMN public.source.source_key_field IS 'The primary key field in th
 COMMENT ON COLUMN public.source.source_number_field IS 'The column holding the main human-readable identifier for this document (e.g. Bill of Materials document number).';
 COMMENT ON COLUMN public.source.source_name_field IS 'The column holding the secondary description of this document (e.g. the Item built by a Bill of Materials).';
 COMMENT ON COLUMN public.source.source_desc_field IS 'The column holding the longer description of this document (e.g. the first line of the Item''s Description for a Bill of Materials).';
+COMMENT ON COLUMN public.source.source_desc_field IS 'The column holding a boolean flag describing whether this document is "active" or not.';
 COMMENT ON COLUMN public.source.source_widget IS 'A hint to the client application of how to let the user select a document to attach. "core" means that the C++ application handles this document type natively. A value starting with "SELECT" is interpreted as a query to populate a combobox, while values containing "Cluster" are treated as the name of a C++ VirtualCluster subclass to instantiate. Empty string means this cannot be used by the desktop client to create document associations (see source_docass).';
 COMMENT ON COLUMN public.source.source_joins IS 'An optional string to add to the FROM clause to get auxiliary information (e.g. "join item_id on bomhead_item_id=item_id").';
 COMMENT ON COLUMN public.source.source_key_param IS 'The name of the parameter interpreted by the desktop client''s "set" method as containing the primary key to retrieve the main document record for editing or viewing (e.g. most desktop windows take the sales order id in a "sohead_id" parameter even though the database field is "cohead_id").';


### PR DESCRIPTION
@davidbeauchamp - Could you review this please? I only added an active parameter to those source records that have a boolean field for this purpose. Let me know if you want this expanded to cover other cases:
-  `(cohead_status = 'O') as cohead_active`
-  (`lsreg_expiredate > current_date`) as lsreg_active`
- etc.