### PR TITLE
issue #28447 - processing the manifest must preserve properties

### DIFF
--- a/scripts/lib/util/process_manifest.js
+++ b/scripts/lib/util/process_manifest.js
@@ -226,14 +226,12 @@ regexp:true, undef:true, strict:true, trailing:true, white:true */
         defaultSchema = defaultSchema || extraManifest.defaultSchema;
         extraManifestScripts = extraManifest.databaseScripts;
         extraManifestScripts = _.map(extraManifestScripts, function (script) {
-            var scriptPath;
-
             if (typeof script === 'object' && script.path) {
-              scriptPath = script.path;
+              script.path = "../../foundation-database/" + script.path;
             } else {
-              scriptPath = script;
+              script = "../../foundation-database/" + script;
             }
-          return "../../foundation-database/" + scriptPath;
+            return script;
         });
         databaseScripts.unshift(extraManifestScripts);
         databaseScripts = _.flatten(databaseScripts);
@@ -254,14 +252,12 @@ regexp:true, undef:true, strict:true, trailing:true, white:true */
         extraManifestScripts = extraManifest.databaseScripts;
         if (alterPaths) {
           extraManifestScripts = _.map(extraManifestScripts, function (script) {
-            var scriptPath;
-
             if (typeof script === 'object' && script.path) {
-              scriptPath = script.path;
+              script.path = "../../foundation-database/" + script.path;
             } else {
-              scriptPath = script;
+              script = "../../foundation-database/" + script;
             }
-            return "../../foundation-database/" + scriptPath;
+            return script;
           });
         }
         databaseScripts.unshift(extraManifestScripts);


### PR DESCRIPTION
The manifest files allow specifying either a filename or an object containing the filename and other properties describing how that file should be loaded into the database, such as grade. This auxiliary information was being stripped off. This change allows build_app.js to tweak the file paths while preserving the extra details.