### PR TITLE
issue #28472 Update adjustInvValue return value

### DIFF
--- a/foundation-database/public/functions/adjustinvvalue.sql
+++ b/foundation-database/public/functions/adjustinvvalue.sql
@@ -1,14 +1,13 @@
-CREATE OR REPLACE FUNCTION adjustInvValue(INTEGER, NUMERIC, INTEGER) RETURNS INTEGER AS $$
+CREATE OR REPLACE FUNCTION adjustInvValue(pItemsiteid   INTEGER, 
+                                          pNewValue     NUMERIC, 
+                                          pAccountid    INTEGER) 
+  RETURNS INTEGER AS $$
 -- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple. 
 -- See www.xtuple.com/CPAL for the full text of the software license.
 DECLARE
-  pItemsiteid     ALIAS FOR $1;
-  pNewValue       ALIAS FOR $2;
-  pAccountid      ALIAS FOR $3;
   _delta          NUMERIC;
   _glreturn       INTEGER;
   _invhistid      INTEGER;
-  _itemlocSeries  INTEGER;
 
 BEGIN
 

--- a/foundation-database/public/functions/adjustinvvalue.sql
+++ b/foundation-database/public/functions/adjustinvvalue.sql
@@ -50,12 +50,13 @@ BEGIN
   FROM itemsite, item, uom
   WHERE ( (itemsite_item_id=item_id)
    AND (item_inv_uom_id=uom_id)
-   AND (itemsite_id=pItemsiteid) );
+   AND (itemsite_id=pItemsiteid) )
+  RETURNING invhist_id INTO _invhistid;
 
   UPDATE itemsite SET itemsite_value=pNewValue
   WHERE (itemsite_id=pItemsiteid);
 
-  RETURN 0;
+  RETURN _invhistid;
 
 END;
 $$ LANGUAGE 'plpgsql';


### PR DESCRIPTION
Prior to this change public.adjustInvValue(intger, number, integer)
would only return 0 on success or -1 on failure.  This change causes a
successful processing to return the invhist_id value of the
public.invhist record created by the function.  The function still
returns -1 on failure.