### PR TITLE
issue #28594 - adjustinvval docnum

### DIFF
--- a/foundation-database/public/functions/adjustinvvalue.sql
+++ b/foundation-database/public/functions/adjustinvvalue.sql
@@ -1,6 +1,9 @@
+DROP FUNCTION IF EXISTS adjustInvValue(INTEGER, NUMERIC, INTEGER);
+
 CREATE OR REPLACE FUNCTION adjustInvValue(pItemsiteid   INTEGER, 
                                           pNewValue     NUMERIC, 
-                                          pAccountid    INTEGER) 
+                                          pAccountid    INTEGER,
+                                          pDocNum       TEXT DEFAULT NULL) 
   RETURNS INTEGER AS $$
 -- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple. 
 -- See www.xtuple.com/CPAL for the full text of the software license.
@@ -42,7 +45,7 @@ BEGIN
   SELECT itemsite_id,
          CURRENT_TIMESTAMP, 'AD', 0.0,
          itemsite_qtyonhand, itemsite_qtyonhand,
-         '', 'Inventory Value Adjustment',
+         COALESCE (pDocNum,''), 'Inventory Value Adjustment',
          uom_name, _delta, FALSE,
          itemsite_costmethod, itemsite_value, pNewValue,
          0

--- a/foundation-database/public/functions/adjustinvvalue.sql
+++ b/foundation-database/public/functions/adjustinvvalue.sql
@@ -37,15 +37,15 @@ BEGIN
   INSERT INTO invhist
    ( invhist_itemsite_id,
      invhist_transdate, invhist_transtype, invhist_invqty,
-     invhist_qoh_before, invhist_qoh_after,
-     invhist_docnumber, invhist_comments,
+     invhist_qoh_before, invhist_qoh_after, invhist_ordtype,
+     invhist_ordnumber, invhist_docnumber, invhist_comments,
      invhist_invuom, invhist_unitcost, invhist_hasdetail,
      invhist_costmethod, invhist_value_before, invhist_value_after,
      invhist_series )
   SELECT itemsite_id,
          CURRENT_TIMESTAMP, 'AD', 0.0,
-         itemsite_qtyonhand, itemsite_qtyonhand,
-         COALESCE (pDocNum,''), 'Inventory Value Adjustment',
+         itemsite_qtyonhand, itemsite_qtyonhand, 'AD',
+         COALESCE (pDocNum,''), '', 'Inventory Value Adjustment',
          uom_name, _delta, FALSE,
          itemsite_costmethod, itemsite_value, pNewValue,
          0

--- a/foundation-database/public/functions/adjustinvvalue.sql
+++ b/foundation-database/public/functions/adjustinvvalue.sql
@@ -9,7 +9,6 @@ CREATE OR REPLACE FUNCTION adjustInvValue(pItemsiteid   INTEGER,
 -- See www.xtuple.com/CPAL for the full text of the software license.
 DECLARE
   _delta          NUMERIC;
-  _glreturn       INTEGER;
   _invhistid      INTEGER;
 
 BEGIN
@@ -23,11 +22,11 @@ BEGIN
     RETURN -1;
   END IF;
 
-  SELECT insertGLTransaction('I/M', '', 'Post Value',
+  PERFORM insertGLTransaction('I/M', '', 'Post Value',
          'Inventory Value Adjustment for ' || item_number,
          COALESCE (pAccountid, costcat_adjustment_accnt_id),
          costcat_asset_accnt_id, -1,
-         _delta, CURRENT_DATE) INTO _glreturn
+         _delta, CURRENT_DATE)
   FROM itemsite
    JOIN costcat ON (itemsite_costcat_id=costcat_id)
    JOIN item ON (itemsite_item_id=item_id)


### PR DESCRIPTION
This pull request is another part of my effort to bring some functional parity between the database average cost inventory valuation functionality and the inventory adjustment function.  In this case, we're bringing document number as an optional parameter to the public.adjustinvvalue function.

Please note that we also populate the invhist_ordtype and invhist_ordnumber fields rather than invhist_docnumber, the inventory adjustment function does this and so we follow its implementation.   The order type field will cause the inventory history report to show "AD-" where before it did not.  This implementation is a departure from the submitted proposal since the invadjustment implementation was misunderstood at the time.