### PR TITLE
Fix CI - Should be able to search the Item through Bar Code

### DIFF
--- a/test/specs/item_site.js
+++ b/test/specs/item_site.js
@@ -180,16 +180,22 @@ setTimeout:true, before:true, clearTimeout:true, exports:true, it:true, describe
       @description Should be able to search the Item through Bar Code
       */
       it("Should be able to search the Item through Bar Code", function (done) {
-        var widget = new XV.ItemSiteWidget(),
-          mockReturn = function (results) {
-            assert.include(_.map(results.models, function (result) {
-              return result.getValue("item.number");
-            }), "BTRUCK1");
-            done();
-          };
+        var btruck1 = new XM.Item();
+        var callback = function () {
+          var barcode = btruck1.get("barcode");
+          var widget = new XV.ItemSiteWidget(),
+            mockReturn = function (results) {
+              assert.include(_.map(results.models, function (result) {
+                return result.getValue("item.number");
+              }), "BTRUCK1");
+              done();
+            };
 
-        widget.$.privateItemSiteWidget.mockReturn = mockReturn;
-        widget.$.privateItemSiteWidget.fetchCollection("739048117066", 10, "mockReturn");
+          widget.$.privateItemSiteWidget.mockReturn = mockReturn;
+          widget.$.privateItemSiteWidget.fetchCollection(barcode, 10, "mockReturn");
+        };
+
+        btruck1.fetch({number: "BTRUCK1", success: callback});
       });
     });
   };


### PR DESCRIPTION
This change uses `randomUPCCode()` now:
https://github.com/xtuple/xtuple/pull/2852/files#diff-5a4b7b76fa139b3797b92c9df7ee9e6fR8353

Change the test to get the `barcode` from the `XM.Item` model vs. hard-coded, then use that for the search.