### PR TITLE
Merge in the latest master before running the tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
   postgresql: 9.3
 
 install:
+  - git merge origin/$TRAVIS_BRANCH
   - pg_lsclusters
   - bash scripts/install_xtuple.sh -ipn -d 9.3
 


### PR DESCRIPTION
This change should fix some of the CI errors we've been seeing by making sure the leading edge is merged in with the PR. It is also a more correct test run, because the PR will be merged, so we should be testing that result.