### PR TITLE
Make sure we can re-build_app the database after an install.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
   - git merge origin/$TRAVIS_BRANCH
   - pg_lsclusters
   - bash scripts/install_xtuple.sh -ipn -d 9.3
+  - scripts/build_app.js
 
 before_script:
   - cd node-datasource


### PR DESCRIPTION
This will slow the test run down a bit, but should catch regressions.