### PR TITLE
Don't delete the Sales Order. It's used by other tests.

### DIFF
--- a/test/specs/sales_order.js
+++ b/test/specs/sales_order.js
@@ -173,6 +173,10 @@ setTimeout:true, before:true, clearTimeout:true, exports:true, it:true, describe
     }
   };
 
+  // Don't CRUD test update or delete. Test uses the created Sales Order for workflow testing.
+  spec.skipDelete = true;
+  spec.skipUpdate = true;
+
   var additionalTests = function () {
 
     describe("Sales order business logic", function () {
@@ -326,6 +330,7 @@ setTimeout:true, before:true, clearTimeout:true, exports:true, it:true, describe
 
       describe("when the sale type changes", function () {
         var saleTypeModel;
+        this.timeout(6000);
 
         before(function (done) {
           async.parallel([


### PR DESCRIPTION
After the latest change, https://github.com/xtuple/private-extensions/pull/857 is now failing CI because the new Sales Order that was created is getting deleted by the `crud.js` test, but the workflow tests use it.

In this repo, `XM.SalesOrder` gets flagged to `skipUpdate` and `skipDelete` for the `criud.js` tests since this change:
https://github.com/xtuple/xtuple/blame/4_11_x/test/specs/printer.js#L215

`printer.js` is not merged into the test run for `private-extensions`, so the test fails when the Sales Order is deleted and later tests try to use it.

This PR just makes the `update` and `delete` skips explicit on the `XM.SalesOrder` test and allows the test to work from `private-extensions` runs.