### PR TITLE
Issue #27791: Work Order and Rental Item are grayed out on "New" menu of documents tab

### DIFF
--- a/foundation-database/public/patches/populate_source.sql
+++ b/foundation-database/public/patches/populate_source.sql
@@ -877,6 +877,6 @@ SELECT createDoctype(97, --pDocAssNum
                      'join cohead on rentline_cohead_id=cohead_id join itemsite on coitem_itemsite_id=itemsite_id join item on itemsite_item_id=item_id', --pJoin
                      'rentine_id', --pParam
                      'rentalItem', --pUi
-                     'MaintainRentalItems', --pPriv
+                     '', --pPriv
                      'Sales' --pModule
 );


### PR DESCRIPTION
Issue is two part, with Work Order there was a typo in the privilege name, work Rental Item the "create" privilege column should be empty as those do not need to be arbitrarily created from the documents tab. 