### PR TITLE
Issue #28882: Add tax field to api.purchaseline

### DIFF
--- a/foundation-database/api/views/purchaseline.sql
+++ b/foundation-database/api/views/purchaseline.sql
@@ -19,6 +19,7 @@
     poitem_manuf_name AS manufacturer_name,
     poitem_manuf_item_number AS manufacturer_item_number,
     poitem_manuf_item_descrip AS manufacturer_description,
+    taxtype_name AS tax_type,
     poitem_comments AS notes,
     formatRevNumber('BOM',poitem_bom_rev_id) AS bill_of_materials_revision,
     formatRevNumber('BOO',poitem_boo_rev_id) AS bill_of_operations_revision,
@@ -33,8 +34,9 @@
     LEFT OUTER JOIN whsinfo ON (itemsite_warehous_id=warehous_id)
     LEFT OUTER JOIN coitem ON (coitem_id=poitem_order_id AND poitem_order_type='S')
     LEFT OUTER JOIN womatl ON (womatl_id=poitem_order_id AND poitem_order_type='W')
+    LEFT OUTER JOIN taxtype ON (taxtype_id = poitem_taxtype_id)
   ORDER BY pohead_number,poitem_linenumber;
---TODO add label to expense category
+
 GRANT ALL ON TABLE api.purchaseline TO xtrole;
 COMMENT ON VIEW api.purchaseline IS 'Purchase Order Line';
 
@@ -55,6 +57,7 @@ COMMENT ON VIEW api.purchaseline IS 'Purchase Order Line';
     poitem_manuf_name,
     poitem_manuf_item_number,
     poitem_manuf_item_descrip,
+    poitem_taxtype_id,
     poitem_comments,
     poitem_expcat_id,
     poitem_freight,
@@ -80,6 +83,7 @@ COMMENT ON VIEW api.purchaseline IS 'Purchase Order Line';
     NEW.manufacturer_name,
     NEW.manufacturer_item_number,
     NEW.manufacturer_description,
+    getTaxTypeId(NEW.tax_type),
     NEW.notes,
     getExpcatId(NEW.expense_category),
     NEW.freight,
@@ -115,6 +119,7 @@ FROM pohead, poitem, charass, char, itemsite, item
     poitem_manuf_name=NEW.manufacturer_name,
     poitem_manuf_item_number=NEW.manufacturer_item_number,
     poitem_manuf_item_descrip=NEW.manufacturer_description,
+    poitem_taxtype_id=getTaxTypeId(NEW.tax_type),
     poitem_comments=NEW.notes,
     poitem_freight=NEW.freight,
     poitem_prj_id=getPrjId(NEW.project_number),


### PR DESCRIPTION
Not adding tax_recoverable field as this is not available on the ui and is not implemented as yet (may never be implemented?)