### PR TITLE
Fixes: #28966 - First char should be lowercase like old camelize()

### DIFF
--- a/enyo-client/application/source/views/list.js
+++ b/enyo-client/application/source/views/list.js
@@ -2794,7 +2794,9 @@ trailing:true, white:true, strict: false*/
     },
 
     determineLabel: function (kindName) {
-      return ("_" + _.pluralize(_.titleize(kindName))).loc();
+      var title = _.titleize(kindName);
+      title = title.charAt(0).toLowerCase() + title.slice(1);
+      return ("_" + _.pluralize(title)).loc();
     }
   });
 


### PR DESCRIPTION
@xtpclark found this testing 4.10. Should back port this fix.

In mobile client, under "Setup", anything in this list did not get translated correctly because they are `kind: "XV.NameList"` inherited:
https://github.com/xtuple/xtuple/blob/4_11_x/enyo-client/application/source/views/list.js#L2826-L2891

When removing the custom `camelize()` function, `titleize()` was used because `camelize()` no longer existed.
https://github.com/xtuple/xtuple/commit/2ec85a7fb47c80e06248d65d42b9ca22db99e87e#diff-c722d458e1cf9717f15054726f196d2cR2797

The problem is, `titleize()` makes the first char capital. This PR makes it lower case so the translation strings match. We ended up with `_IncidentCategories` instead of `_incidentCategories`.

