### PR TITLE
issue #29358 - pg_restore sets small search_path when refreshing materialized views

### DIFF
--- a/foundation-database/public/functions/getcurrid.sql
+++ b/foundation-database/public/functions/getcurrid.sql
@@ -1,21 +1,18 @@
 CREATE OR REPLACE FUNCTION getCurrId(pCurrName text) RETURNS INTEGER STABLE AS $$
--- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple. 
+-- Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
 DECLARE
   _returnVal INTEGER;
 BEGIN
-  IF (pCurrName IS NULL) THEN
-	RETURN NULL;
-  END IF;
-
   SELECT curr_id INTO _returnVal
-  FROM curr_symbol
-  WHERE (curr_abbr=pCurrName);
+    FROM public.curr_symbol   -- schema-qualified for bug 29358; generally bad
+   WHERE curr_abbr = pCurrName;
 
-  IF (_returnVal IS NULL) THEN
-	RAISE EXCEPTION 'Currency % not found.', pCurrName;
+  IF pCurrName IS NOT NULL AND _returnVal IS NULL THEN
+    RAISE EXCEPTION 'Currency % not found [xtuple: getCurrId, -1, %]',
+                    pCurrName, pCurrName;
   END IF;
 
   RETURN _returnVal;
 END;
-$$ LANGUAGE 'plpgsql';
+$$ LANGUAGE plpgsql;

--- a/test/database/functions/currtobase.js
+++ b/test/database/functions/currtobase.js
@@ -1,0 +1,139 @@
+var _      = require('underscore'),
+    assert = require('chai').assert,
+    dblib  = require('../dblib');
+
+(function () {
+  'use strict';
+
+  describe('currToBase()', function () {
+    var adminCred   = dblib.adminCred,
+        datasource  = dblib.datasource,
+        closeEnough = 0.006,
+        basecurr, altcurr;
+
+    it("needs base and alternate currency info", function (done) {
+      var sql = "select s.curr_id AS id, curr_base AS isbase,"              +
+                "       min(curr_effective) AS mindate,"                    +
+                "       max(curr_expires) AS maxdate,"                      +
+                "       (select curr_rate from curr_rate"                   +
+                "         where curr_id = s.curr_id"                        +
+                "           and current_date between curr_effective and"    +
+                "                                    curr_expires) AS rate" +
+                "  from curr_symbol s"                                      +
+                "  join curr_rate   r ON s.curr_id = r.curr_id"             +
+                " group by s.curr_id"                                       +
+                " order by curr_base desc"                                  +
+                " limit 2;";
+      datasource.query(sql, adminCred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 2);
+        assert.isTrue(res.rows[0].isbase);
+        basecurr = res.rows[0];
+        altcurr  = res.rows[1];
+        done();
+      });
+    });
+
+    it("needs alternate currency exchange rate", function (done) {
+      var sql = "insert into curr_rate ("                                +
+                "  curr_id, curr_rate, curr_effective, curr_expires"     +
+                ") values ("                                             +
+                "  $1, 1.5, current_date, current_date + interval '1 day'" +
+                ") returning curr_rate;",
+          cred = _.extend({}, adminCred, { parameters: [ altcurr.id ] });
+      if (altcurr.rate) {
+        done();
+      } else {
+        datasource.query(sql, cred, function (err, res) {
+          assert.isNull(err);
+          if (res.rowCount >= 1) {
+            altcurr.rate = res.rows[0].curr_rate;
+          }
+          done();
+        });
+      }
+    });
+
+    it("should fail if bad currency", function (done) {
+      var sql = "select currToBase(-1, 1, current_date) as result;";
+      datasource.query(sql, adminCred, function (err, res) {
+        dblib.assertErrorCode(err, res, 'currToBase', -1);
+        done();
+      });
+    });
+
+    it("should fail if bad date", function (done) {
+      var sql = "select currToBase($1, 1.0, '1900-01-01') as result;",
+          cred = _.extend({}, adminCred, { parameters: [ altcurr.id ] });
+      datasource.query(sql, cred, function (err, res) {
+        dblib.assertErrorCode(err, res, 'currToBase', -1);
+        done();
+      });
+    });
+
+    it("should succeed for base currency", function (done) {
+      var sql = "select currToBase($1, 1.0, CURRENT_DATE) as result;",
+          cred = _.extend({}, adminCred, { parameters: [ basecurr.id ] });
+      datasource.query(sql, cred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        assert.closeTo(res.rows[0].result, 1.0, closeEnough);
+        done();
+      });
+    });
+
+    it("should succeed with null value", function (done) {
+      var sql = "select currToBase(-1, NULL, '1900-01-01') as result;";
+      datasource.query(sql, adminCred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        assert.closeTo(res.rows[0].result, 0, closeEnough);
+        done();
+      });
+    });
+
+    it("should succeed with 0.0", function (done) {
+      var sql = "select currToBase(-1, 0.0, '1900-01-01') as result;";
+      datasource.query(sql, adminCred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        assert.closeTo(res.rows[0].result, 0, closeEnough);
+        done();
+      });
+    });
+
+    it("should succeed for non-base currency", function (done) {
+      var sql = "select currToBase($1, 1.0, CURRENT_DATE) as result;",
+          cred = _.extend({}, adminCred, { parameters: [ altcurr.id ] });
+      datasource.query(sql, cred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        assert.closeTo(res.rows[0].result, 1.0 / altcurr.rate, closeEnough);
+        done();
+      });
+    });
+
+    it("should succeed for good date", function (done) {
+      var sql = "select currToBase($1, 1.0, $2) as result;",
+          cred = _.extend({}, adminCred, { parameters: [ altcurr.id, altcurr.mindate ] });
+      datasource.query(sql, cred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        assert.notEqual(res.rows[0].result, 1.0);
+        done();
+      });
+    });
+
+    it("should succeed for null date", function (done) {
+      var sql = "select currToBase($1, 1.0, NULL) as result;",
+          cred = _.extend({}, adminCred, { parameters: [ altcurr.id ] });
+      datasource.query(sql, cred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        assert.closeTo(res.rows[0].result, 1.0 / altcurr.rate, closeEnough);
+        done();
+      });
+    });
+
+  });
+}());

--- a/test/database/functions/getcurrid.js
+++ b/test/database/functions/getcurrid.js
@@ -1,0 +1,39 @@
+var assert = require('chai').assert,
+    dblib  = require('../dblib');
+
+(function () {
+  'use strict';
+
+  describe('getcurrid()', function () {
+    var adminCred   = dblib.adminCred,
+        datasource  = dblib.datasource;
+
+    it("should return null for null currency", function (done) {
+      var sql = "select getCurrId(NULL) as result;";
+      datasource.query(sql, adminCred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        assert.isNull(res.rows[0].result);
+        done();
+      });
+    });
+
+    it("should fail if bad currency", function (done) {
+      var sql = "select getCurrId('ABC') as result;";
+      datasource.query(sql, adminCred, function (err, res) {
+        dblib.assertErrorCode(err, res, 'getCurrId', -1);
+        done();
+      });
+    });
+
+    it("should succeed for valid currency", function (done) {
+      var sql = "select getCurrId('USD') as result;";
+      datasource.query(sql, adminCred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        done();
+      });
+    });
+
+  });
+}());


### PR DESCRIPTION
This is an indirect fix for 29358. The bug won't really be fixed until we have reference databases that contain these versions of the functions.