### PR TITLE
Fixes #29591 The `usr` view is slow on databases with lots of `usrpref` records

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ dist:     trusty
 node_js:
   - "0.10"
 addons:
-  postgresql: 9.4
+  postgresql: 9.3
 
 install:
   - git merge origin/$TRAVIS_BRANCH
   - pg_lsclusters
-  - bash scripts/install_xtuple.sh -ipn -d 9.4
+  - bash scripts/install_xtuple.sh -ipn -d 9.3
   - scripts/build_app.js
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ dist:     trusty
 node_js:
   - "0.10"
 addons:
-  postgresql: 9.3
+  postgresql: 9.5
 
 install:
   - git merge origin/$TRAVIS_BRANCH
   - pg_lsclusters
-  - bash scripts/install_xtuple.sh -ipn -d 9.3
+  - bash scripts/install_xtuple.sh -ipn -d 9.5
   - scripts/build_app.js
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ dist:     trusty
 node_js:
   - "0.10"
 addons:
-  postgresql: 9.5
+  postgresql: 9.4
 
 install:
   - git merge origin/$TRAVIS_BRANCH
   - pg_lsclusters
-  - bash scripts/install_xtuple.sh -ipn -d 9.5
+  - bash scripts/install_xtuple.sh -ipn -d 9.4
   - scripts/build_app.js
 
 before_script:

--- a/foundation-database/public/functions/usercanlogin.sql
+++ b/foundation-database/public/functions/usercanlogin.sql
@@ -1,7 +1,7 @@
 --DROP VIEW     IF EXISTS usr;
 --DROP FUNCTION IF EXISTS userCanLogin(TEXT);
 CREATE OR REPLACE FUNCTION userCanLogin(pUsername TEXT) RETURNS BOOLEAN AS $$
--- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple. 
+-- Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
 DECLARE
   _isactive  BOOLEAN;
@@ -33,5 +33,4 @@ BEGIN
 
   RETURN FALSE;
 END;
-$$ LANGUAGE 'plpgsql';
-
+$$ LANGUAGE 'plpgsql' STABLE;

--- a/foundation-database/public/views/usr.sql
+++ b/foundation-database/public/views/usr.sql
@@ -57,6 +57,8 @@ SELECT xt.create_view('public.usr', $BODY$
                   'propername',
                   'window'
                 ]) AS name
+               ORDER BY
+                name
             ) AS pref_names
             LEFT JOIN (
               -- Join the user's pref settings with the dummy table.
@@ -75,6 +77,9 @@ SELECT xt.create_view('public.usr', $BODY$
                    'propername',
                    'window'
                  )
+               ORDER BY
+                username,
+                name
             ) AS userprefs USING (name)
            -- Make sure they are alpha ordered so the array access operators above know which is which.
            ORDER BY

--- a/foundation-database/public/views/usr.sql
+++ b/foundation-database/public/views/usr.sql
@@ -1,20 +1,87 @@
+SELECT xt.create_view('public.usr', $BODY$
+-- Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
+-- See www.xtuple.com/EULA for the full text of the software license.
 
---SELECT dropIfExists('VIEW', 'usr');
-CREATE OR REPLACE VIEW usr AS
-  SELECT usesysid::integer AS usr_id,
-         usename::text AS usr_username,
-         COALESCE((SELECT usrpref_value FROM usrpref WHERE usrpref_username=usename AND usrpref_name='propername'), '') AS usr_propername,
-         null::text AS usr_passwd,
-         COALESCE((SELECT CAST(usrpref_value AS INTEGER) FROM usrpref WHERE usrpref_username=usename AND usrpref_name='locale_id'),
-           COALESCE((SELECT locale_id FROM locale WHERE lower(locale_code) = 'default' LIMIT 1), (SELECT locale_id FROM locale ORDER BY locale_id LIMIT 1))) AS usr_locale_id,
-         COALESCE((SELECT usrpref_value FROM usrpref WHERE usrpref_username=usename AND usrpref_name='initials'), '') AS usr_initials,
-         COALESCE((SELECT CASE WHEN usrpref_value='t' THEN true ELSE false END FROM usrpref WHERE usrpref_username=usename AND usrpref_name='agent'), false) AS usr_agent,
-         COALESCE((SELECT CASE WHEN usrpref_value='t' THEN true ELSE false END FROM usrpref WHERE usrpref_username=usename AND usrpref_name='active'), userCanLogin(usename)) AS usr_active,
-         COALESCE((SELECT usrpref_value FROM usrpref WHERE usrpref_username=usename AND usrpref_name='email'), '') AS usr_email,
-         COALESCE((SELECT usrpref_value FROM usrpref WHERE usrpref_username=usename AND usrpref_name='window'), '') AS usr_window
-    FROM pg_user;
+  WITH default_locale AS (
+    SELECT
+      locale_id,
+      1 AS sort
+      FROM locale
+     WHERE lower(locale_code) = 'default'
 
+    UNION
+    SELECT
+      locale_id,
+      2 AS sort
+      FROM (
+        SELECT
+          locale_id
+          FROM locale
+         ORDER BY locale_id
+      ) AS locale_sort
+     ORDER BY sort
+     LIMIT 1
+  )
+  SELECT
+    usesysid::integer AS usr_id,
+    usename::text AS usr_username,
+    COALESCE(value[6], '') AS usr_propername,
+    null::text AS usr_passwd,
+    COALESCE(value[5]::integer, (SELECT locale_id FROM default_locale)) AS usr_locale_id,
+    COALESCE(value[4], '') AS usr_initials,
+    COALESCE((value[2] = 't'), false) AS usr_agent,
+    COALESCE((value[1] = 't'), usercanlogin(usename::text), false) AS usr_active,
+    COALESCE(value[3], '') AS usr_email,
+    COALESCE(value[7], '') AS usr_window
+    FROM pg_user
+    LEFT JOIN (
+      SELECT
+        username,
+        -- Roll the value pairs up into an array for each user.
+        --array_agg(name) AS name, -- Not actually used above, but helpful for debugging.
+        array_agg(value) AS value
+        FROM (
+          SELECT
+            username,
+            name,
+            value
+            FROM (
+              -- Make a dummy table of the pref names to serve as default rows if not set for the user.
+              SELECT
+                unnest(ARRAY[
+                  'active',
+                  'agent',
+                  'email',
+                  'initials',
+                  'locale_id',
+                  'propername',
+                  'window'
+                ]) AS name
+            ) AS pref_names
+            LEFT JOIN (
+              -- Join the user's pref settings with the dummy table.
+              SELECT
+                usrpref_username AS username,
+                usrpref_name AS name,
+                usrpref_value AS value
+                FROM usrpref
+               WHERE true
+                 AND usrpref_name IN (
+                   'active',
+                   'agent',
+                   'email',
+                   'initials',
+                   'locale_id',
+                   'propername',
+                   'window'
+                 )
+            ) AS userprefs USING (name)
+           -- Make sure they are alpha ordered so the array access operators above know which is which.
+           ORDER BY
+            username,
+            name
+        ) AS userprefs
+       GROUP BY username
+  ) AS usrprefs ON pg_user.usename = usrprefs.username;
 
-REVOKE ALL ON TABLE usr FROM PUBLIC;
-GRANT  ALL ON TABLE usr TO GROUP xtrole;
-
+$BODY$, false);

--- a/foundation-database/public/views/usr.sql
+++ b/foundation-database/public/views/usr.sql
@@ -5,21 +5,11 @@ SELECT xt.create_view('public.usr', $BODY$
   WITH default_locale AS (
     SELECT
       locale_id,
-      1 AS sort
+      NOT (lower(locale_code) = 'default') AS sort
       FROM locale
-     WHERE lower(locale_code) = 'default'
-
-    UNION
-    SELECT
-      locale_id,
-      2 AS sort
-      FROM (
-        SELECT
-          locale_id
-          FROM locale
-         ORDER BY locale_id
-      ) AS locale_sort
-     ORDER BY sort
+     ORDER BY
+      sort,
+      locale_id
      LIMIT 1
   )
   SELECT
@@ -30,7 +20,7 @@ SELECT xt.create_view('public.usr', $BODY$
     COALESCE(value[5]::integer, (SELECT locale_id FROM default_locale)) AS usr_locale_id,
     COALESCE(value[4], '') AS usr_initials,
     COALESCE((value[2] = 't'), false) AS usr_agent,
-    COALESCE((value[1] = 't'), usercanlogin(usr_username::text), false) AS usr_active,
+    COALESCE((value[1] = 't'), false) AS usr_active,
     COALESCE(value[3], '') AS usr_email,
     COALESCE(value[7], '') AS usr_window
     FROM (

--- a/scripts/install_xtuple.sh
+++ b/scripts/install_xtuple.sh
@@ -177,11 +177,11 @@ install_packages() {
 
   # we had problems with a newer plv8 in mar-apr 2016
   local PLV8PKG="postgresql-${PG_VERSION}-plv8"
-  if [ ${PG_VERSION} = 9.3 ] ; then
+#  if [ ${PG_VERSION} = 9.3 ] ; then
 #    PLV8PKG="postgresql-${PG_VERSION}-plv8=1.4.0.ds-2"
-  elif [ ${PG_VERSION} = 9.4 ] ; then
+#  elif [ ${PG_VERSION} = 9.4 ] ; then
 #    PLV8PKG="postgresql-${PG_VERSION}-plv8=1:1.4.8.ds-1.pgdg14.04+1"
-  fi
+#  fi
 
   sudo apt-get -qq -y install --force-yes \
     postgresql-${PG_VERSION} postgresql-server-dev-${PG_VERSION} \

--- a/scripts/install_xtuple.sh
+++ b/scripts/install_xtuple.sh
@@ -165,7 +165,6 @@ install_packages() {
       ;;
   esac
 
-  #sudo add-apt-repository -y "deb http://apt.postgresql.org/pub/repos/apt/ ${DEBDIST}-pgdg main"
   sudo apt-get -qq update |& tee -a $LOG_FILE
 
   # we won't support pg 9.1 in 4.10 or later
@@ -175,12 +174,14 @@ install_packages() {
       postgresql-9.1-asn1oid postgresql-9.1-plv8 2>&1
   fi
 
-  # we had problems with a newer plv8 in mar-apr 2016
   local PLV8PKG="postgresql-${PG_VERSION}-plv8"
+
+# we had problems with a newer plv8 in mar-apr 2016, but it's working in Feb-2017.
 #  if [ ${PG_VERSION} = 9.3 ] ; then
 #    PLV8PKG="postgresql-${PG_VERSION}-plv8=1.4.0.ds-2"
 #  elif [ ${PG_VERSION} = 9.4 ] ; then
-#    PLV8PKG="postgresql-${PG_VERSION}-plv8=1:1.4.8.ds-1.pgdg14.04+1"
+#    PLV8PKG="postgresql-${PG_VERSION}-plv8=1:1.4.8.ds-2.pgdg14.04+1"
+     # Now installs (note: ds-2): postgresql-9.4-plv8 (1:1.4.8.ds-2.pgdg14.04+1) ...
 #  fi
 
   sudo apt-get -qq -y install --force-yes \

--- a/scripts/install_xtuple.sh
+++ b/scripts/install_xtuple.sh
@@ -150,7 +150,22 @@ install_packages() {
     # for Debian wheezy (7.x) we need some things from the wheezy-backports
     sudo add-apt-repository -y "deb http://ftp.debian.org/debian wheezy-backports main"
   fi
-  sudo add-apt-repository -y "deb http://apt.postgresql.org/pub/repos/apt/ ${DEBDIST}-pgdg main"
+
+  case "${DEBDIST}" in
+      "trusty") ;&
+      "utopic") ;&
+      "wheezy") ;&
+      "jessie") ;&
+      "xenial")
+          # check to make sure the PostgreSQL repo is already added on the system
+          if [ ! -f /etc/apt/sources.list.d/pgdg.list ] || ! grep -q "apt.postgresql.org" /etc/apt/sources.list.d/pgdg.list; then
+              sudo bash -c "wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -"
+              sudo bash -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          fi
+      ;;
+  esac
+
+  #sudo add-apt-repository -y "deb http://apt.postgresql.org/pub/repos/apt/ ${DEBDIST}-pgdg main"
   sudo apt-get -qq update |& tee -a $LOG_FILE
 
   # we won't support pg 9.1 in 4.10 or later
@@ -163,9 +178,9 @@ install_packages() {
   # we had problems with a newer plv8 in mar-apr 2016
   local PLV8PKG="postgresql-${PG_VERSION}-plv8"
   if [ ${PG_VERSION} = 9.3 ] ; then
-    PLV8PKG="postgresql-${PG_VERSION}-plv8=1.4.0.ds-2"
+#    PLV8PKG="postgresql-${PG_VERSION}-plv8=1.4.0.ds-2"
   elif [ ${PG_VERSION} = 9.4 ] ; then
-    PLV8PKG="postgresql-${PG_VERSION}-plv8=1:1.4.8.ds-1.pgdg14.04+1"
+#    PLV8PKG="postgresql-${PG_VERSION}-plv8=1:1.4.8.ds-1.pgdg14.04+1"
   fi
 
   sudo apt-get -qq -y install --force-yes \

--- a/test/specs/activity.js
+++ b/test/specs/activity.js
@@ -49,7 +49,7 @@ before:true, exports:true, it:true, describe:true, XG:true */
       this.timeout(40000);
       var model = actList.value.models[0],
         assignedTo = model.get("assignedTo") ? model.getValue("assignedTo.username") : null,
-        newAssignedTo = assignedTo === "postgres" ? "admin" : "postgres",
+        newAssignedTo = assignedTo === "admin" ? "postgres" : "admin",
         popup;
 
       // Select the first model from the list, call the reassignUser function


### PR DESCRIPTION
@mdathe tested this on a database with 400,000+ `usrpref` records and saw an order of magnitude performance increase.