### PR TITLE
issue #29788 - itemlocdist_source_id_idx - 15min to 1.5min

### DIFF
--- a/foundation-database/manifest.js
+++ b/foundation-database/manifest.js
@@ -51,6 +51,7 @@
     "public/indexes/invchead.sql",
     "public/indexes/invcheadtax.sql",
     "public/indexes/invcitemtax.sql",
+    "public/indexes/itemlocdist.sql",
     "public/indexes/shipitem.sql",
     "public/indexes/taxhist.sql",
     "public/indexes/voheadtax.sql",

--- a/foundation-database/public/functions/formatlocationname.sql
+++ b/foundation-database/public/functions/formatlocationname.sql
@@ -12,7 +12,7 @@ BEGIN
     FROM location
    WHERE location_id = pLocationid;
 
-  RETURN COALESCE(_name, 'NA');
+  RETURN COALESCE(_name, 'N/A');
 
 END;
 $$ LANGUAGE plpgsql;

--- a/foundation-database/public/functions/formatlocationname.sql
+++ b/foundation-database/public/functions/formatlocationname.sql
@@ -1,42 +1,19 @@
 
-CREATE OR REPLACE FUNCTION formatLocationName(INTEGER) RETURNS TEXT IMMUTABLE AS '
--- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple. 
+CREATE OR REPLACE FUNCTION formatLocationName(pLocationid INTEGER) RETURNS TEXT IMMUTABLE AS $$
+-- Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple. 
 -- See www.xtuple.com/CPAL for the full text of the software license.
 DECLARE
-  pLocationid ALIAS FOR $1;
   _name TEXT;
-  _r RECORD;
 
 BEGIN
+  SELECT COALESCE(location_aisle, '') || COALESCE(location_rack, '')
+      || COALESCE(location_bin,   '') || COALESCE(location_name, '')
+    INTO _name
+    FROM location
+   WHERE location_id = pLocationid;
 
-  SELECT location_aisle, location_rack,
-         location_bin, location_name INTO _r
-  FROM location
-  WHERE (location_id=pLocationid);
-  IF (FOUND) THEN
-    IF (_r.location_aisle IS NOT NULL) THEN
-      _name := _r.location_aisle;
-    ELSE
-      _name := '''';
-    END IF;
-
-    IF (_r.location_rack IS NOT NULL) THEN
-      _name := (_name || _r.location_rack);
-    END IF;
-
-    IF (_r.location_bin IS NOT NULL) THEN
-      _name := (_name || _r.location_bin);
-    END IF;
-
-    IF (_r.location_name IS NOT NULL) THEN
-      _name := (_name || _r.location_name);
-    END IF;
-
-    RETURN _name;
-  ELSE
-    RETURN ''N/A'';
-  END IF;
+  RETURN COALESCE(_name, 'NA');
 
 END;
-' LANGUAGE 'plpgsql';
+$$ LANGUAGE plpgsql;
 

--- a/foundation-database/public/indexes/itemlocdist.sql
+++ b/foundation-database/public/indexes/itemlocdist.sql
@@ -1,0 +1,1 @@
+select xt.add_index('itemlocdist', 'itemlocdist_source_id', 'itemlocdist_source_id_idx', 'btree', 'public');

--- a/foundation-database/public/tables/itemlocdist.sql
+++ b/foundation-database/public/tables/itemlocdist.sql
@@ -1,5 +1,25 @@
-select xt.add_column('itemlocdist', 'itemlocdist_child_series', 'INTEGER', NULL, 'public');
-select xt.add_column('itemlocdist', 'itemlocdist_transtype', 'TEXT', NULL, 'public');
+
+SELECT xt.create_table('itemlocdist', 'public');
+SELECT xt.add_column('itemlocdist', 'itemlocdist_id',             'SERIAL',        'PRIMARY KEY', 'public'),
+       xt.add_column('itemlocdist', 'itemlocdist_itemlocdist_id', 'INTEGER',       NULL, 'public'),
+       xt.add_column('itemlocdist', 'itemlocdist_source_type',    'CHARACTER(1)',  NULL, 'public'),
+       xt.add_column('itemlocdist', 'itemlocdist_source_id',      'INTEGER',       NULL, 'public'),
+       xt.add_column('itemlocdist', 'itemlocdist_qty',            'NUMERIC(18,6)', NULL, 'public'),
+       xt.add_column('itemlocdist', 'itemlocdist_series',         'INTEGER',       NULL, 'public'),
+       xt.add_column('itemlocdist', 'itemlocdist_invhist_id',     'INTEGER',       NULL, 'public'),
+       xt.add_column('itemlocdist', 'itemlocdist_itemsite_id',    'INTEGER',       NULL, 'public'),
+       xt.add_column('itemlocdist', 'itemlocdist_reqlotserial',   'BOOLEAN',       'DEFAULT false', 'public'),
+       xt.add_column('itemlocdist', 'itemlocdist_flush',          'BOOLEAN',       'DEFAULT false', 'public'),
+       xt.add_column('itemlocdist', 'itemlocdist_expiration',     'DATE',          NULL, 'public'),
+       xt.add_column('itemlocdist', 'itemlocdist_distlotserial',  'BOOLEAN',       NULL, 'public'),
+       xt.add_column('itemlocdist', 'itemlocdist_warranty',       'DATE',          NULL, 'public'),
+       xt.add_column('itemlocdist', 'itemlocdist_ls_id',          'INTEGER',       NULL, 'public'),
+       xt.add_column('itemlocdist', 'itemlocdist_order_type',     'TEXT',          NULL, 'public'),
+       xt.add_column('itemlocdist', 'itemlocdist_order_id',       'INTEGER',       NULL, 'public'),
+       xt.add_column('itemlocdist', 'itemlocdist_child_series',   'INTEGER',       NULL, 'public'),
+       xt.add_column('itemlocdist', 'itemlocdist_transtype',      'TEXT',          NULL, 'public');
+
+--SELECT xt.add_constraint('itemlocdist', 'itemlocdist_itemlocdist_id_fkey', 'FOREIGN KEY (itemlocdist_itemlocdist_id) REFERENCES itemlocdist(itemlocdist_id)', 'public');
 
 COMMENT ON COLUMN public.itemlocdist.itemlocdist_order_id
   IS 'This is actually orderitem_id';


### PR DESCRIPTION
Adding an index on the source id improves performance significantly.
Adding a foreign key constraint on itemlocdist_itemlocdist_id_fkey
should also help but exposes a bug in inventory distribution
cleanup.
Simplifying the formatlocationname function speeds it up by
about 10% (not much but the code is much easier to read now).