### PR TITLE
fix plv8 config forward reference err

### DIFF
--- a/foundation-database/manifest.js
+++ b/foundation-database/manifest.js
@@ -18,13 +18,13 @@
     "../lib/orm/source/xt/tables/js.sql",
     "../lib/orm/source/create_uuid-ossp.sql",
     "../lib/orm/source/create_plv8.sql",
+    "../lib/orm/source/xt/functions/js_init.sql",
     "../lib/orm/source/xt/functions/create_view.sql",
     "../lib/orm/source/xt/functions/install_js.sql",
     "../lib/orm/source/xt/functions/raise_debug.sql",
     "../lib/orm/source/xt/functions/raise_exception.sql",
     "../lib/orm/source/xt/functions/raise_warning.sql",
 
-    "../lib/orm/source/xt/functions/js_init.sql",
     "../lib/orm/source/reset_search_path.sql",
 
     "public/tables/pkghead.sql",


### PR DESCRIPTION
plv8 started raising errors when running the first `language plv8` function if the init function hadn't been defined yet