### PR TITLE
fix another plv8 config forward reference err

### DIFF
--- a/lib/orm/source/create_plv8.sql
+++ b/lib/orm/source/create_plv8.sql
@@ -1,1 +1,5 @@
+-- dummy function avoids forward reference bug with some plv8 versions
+CREATE OR REPLACE FUNCTION xt.js_init(debug BOOLEAN DEFAULT false, initialize BOOLEAN DEFAULT false)
+RETURNS VOID AS $$ BEGIN RETURN; END; $$ LANGUAGE plpgsql;
+
 CREATE EXTENSION IF NOT EXISTS plv8;


### PR DESCRIPTION
some versions of plv8 seem to need the init function defined _before_ the extension is created. create a dummy version to bootstrap.