### PR TITLE
prep for 4.11.0-beta - fix problems loading extensions

### DIFF
--- a/foundation-database/manifest.js
+++ b/foundation-database/manifest.js
@@ -28,6 +28,8 @@
     "../lib/orm/source/xt/functions/uuid_generate_v4.sql",
 
     "../lib/orm/source/reset_search_path.sql",
+    "../database/source/xt/functions/add_priv.sql",
+    "../database/source/xt/functions/grant_role_priv.sql",
 
     "public/tables/pkghead.sql",
     "public/tables/itemlocdist.sql",

--- a/scripts/release_build.sh
+++ b/scripts/release_build.sh
@@ -98,7 +98,11 @@ setConfig() {
 gitco() {
   local REPO=$1
   local GITTAG=$(getConfig $REPO tag)
-  if [ "$GITTAG" == skip ] ; then
+  if [ ! -d $XTUPLEDIR/../$REPO ] ; then
+    GITTAG=default
+    cd $XTUPLEDIR/..
+    git clone https://github.com/xtuple/${REPO}.git
+  elif [ "$GITTAG" == skip ] ; then
     return 0;
   fi
 


### PR DESCRIPTION
requires xtdash and nodejsshim 1.0.0-rc.2, xtte 2.4.3
for those extensions to load properly. this pass expects
those repositories to be checked out at the right version
before starting the script.