### PR TITLE
issue #30157 - calculate applicable and non-app ar applications, not filter them

### DIFF
--- a/foundation-database/public/tables/metasql/arOpenItems-detail.mql
+++ b/foundation-database/public/tables/metasql/arOpenItems-detail.mql
@@ -1,18 +1,18 @@
 -- Group: arOpenItems
 -- Name: detail
 -- Notes: used by arWorkBench, dspAROpenItems
--- Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
--- See www.xtuple.com/CPAL for the full text of the software license.
+--        Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
+--        See www.xtuple.com/CPAL for the full text of the software license.
 
 <? if exists("totalOnly") ?>
 SELECT SUM(CASE WHEN (aropen_doctype IN ('C', 'R')) THEN
                     (aropen_amount - aropen_paid) / aropen_curr_rate * -1
                 ELSE (aropen_amount - aropen_paid) / aropen_curr_rate
            END) AS total_balance
-FROM aropen JOIN custinfo ON (aropen_cust_id=cust_id)
-            LEFT OUTER JOIN custtype ON (cust_custtype_id=custtype_id)
-            LEFT OUTER JOIN custgrpitem ON (custgrpitem_cust_id=cust_id)
-WHERE ( (aropen_open)
+  FROM aropen JOIN custinfo ON (aropen_cust_id=cust_id)
+  LEFT OUTER JOIN custtype ON (cust_custtype_id=custtype_id)
+  LEFT OUTER JOIN custgrpitem ON (custgrpitem_cust_id=cust_id)
+ WHERE aropen_open
 <? if exists("cust_id") ?>
   AND   (aropen_cust_id=<? value("cust_id") ?>)
 <? endif ?>
@@ -25,7 +25,7 @@ WHERE ( (aropen_open)
 <? if exists("custgrp_id") ?>
   AND   (custgrpitem_custgrp_id=<? value("custgrp_id") ?>)
 <? endif ?>
-      )
+
 ;
 <? else ?>
 
@@ -191,12 +191,23 @@ UNION
 <? endif ?>
 
 -- Get Posted AR Open
+WITH arapply_summarized AS (
+  SELECT arapply_source_aropen_id, arapply_source_doctype, arapply_source_docnumber,
+         arapply_target_aropen_id, arapply_target_doctype, arapply_target_docnumber,
+         SUM(CASE WHEN arapply_distdate <= COALESCE(<? value('asofDate') ?>, CURRENT_DATE)
+                  THEN arapply_target_paid ELSE 0 END) AS arapply_distributable_amount,
+         SUM(CASE WHEN arapply_distdate >  COALESCE(<? value('asofDate') ?>, CURRENT_DATE)
+                  THEN arapply_target_paid ELSE 0 END) AS arapply_non_distributable_amount
+    FROM arapply
+   GROUP BY arapply_source_aropen_id, arapply_source_doctype, arapply_source_docnumber,
+            arapply_target_aropen_id, arapply_target_doctype, arapply_target_docnumber
+)
 SELECT aropen_id AS id,
-       CASE WHEN (aropen_doctype='I') THEN 0
-            WHEN (aropen_doctype='C') THEN 1
-            WHEN (aropen_doctype='D') THEN 2
-            WHEN (aropen_doctype='R') THEN 3
-            ELSE -1
+       CASE aropen_doctype WHEN 'I' THEN 0
+                           WHEN 'C' THEN 1
+                           WHEN 'D' THEN 2
+                           WHEN 'R' THEN 3
+                           ELSE -1
        END AS altId,
        aropen_docnumber AS docnumber,
        COALESCE(invchead_id,cmhead_id,-1) AS docnumber_xtidrole,
@@ -206,32 +217,31 @@ SELECT aropen_id AS id,
        aropen_ordernumber AS ordernumber,
        aropen_ponumber AS custpo,
        COALESCE(cohead_id,-1) AS ordernumber_xtidrole,
-       CASE WHEN (aropen_doctype='I') THEN <? value("invoice") ?>
-            WHEN (aropen_doctype='C') THEN <? value("creditMemo") ?>
-            WHEN (aropen_doctype='D') THEN <? value("debitMemo") ?>
-            WHEN (aropen_doctype='R') THEN <? value("cashdeposit") ?>
-            ELSE <? value("other") ?>
+       CASE aropen_doctype WHEN 'I' THEN <? value("invoice") ?>
+                           WHEN 'C' THEN <? value("creditMemo") ?>
+                           WHEN 'D' THEN <? value("debitMemo") ?>
+                           WHEN 'R' THEN <? value("cashdeposit") ?>
+                           ELSE aropen_doctype
        END AS doctype,
-       CASE WHEN (aropen_doctype='C') THEN 'emphasis' 
-         ELSE CASE WHEN(aropen_doctype='R')THEN 'altemphasis'
-         END
+       CASE aropen_doctype WHEN 'C' THEN 'emphasis' 
+                           WHEN 'R' THEN 'altemphasis'
        END AS doctype_qtforegroundrole,
        aropen_amount AS amount,
-       aropen_amount/aropen_curr_rate AS base_amount,
-       (aropen_paid - (COALESCE(SUM(arapply_target_paid),0))) AS paid,
-       (aropen_paid - (COALESCE(SUM(arapply_target_paid),0))/aropen_curr_rate) AS base_paid,
-        (((aropen_amount-aropen_paid+COALESCE(SUM(arapply_target_paid),0))) *
-        CASE WHEN (aropen_doctype IN ('C', 'R')) THEN -1 ELSE 1 END) AS balance,
+       aropen_amount / aropen_curr_rate AS base_amount,
+        aropen_paid - COALESCE(arapply_non_distributable_amount, 0) AS paid,
+       (aropen_paid - COALESCE(arapply_non_distributable_amount, 0)) / aropen_curr_rate AS base_paid,
+       (aropen_amount - COALESCE(arapply_distributable_amount, 0)) *
+        CASE WHEN aropen_doctype IN ('C', 'R') THEN -1 ELSE 1 END AS balance,
        currConcat(aropen_curr_id) AS currAbbr,
-        (((aropen_amount-aropen_paid+COALESCE(SUM(arapply_target_paid),0)))/aropen_curr_rate *
-        CASE WHEN (aropen_doctype IN ('C', 'R')) THEN -1 ELSE 1 END)  AS base_balance,
+       (aropen_amount - COALESCE(arapply_distributable_amount, 0)) / aropen_curr_rate *
+        CASE WHEN aropen_doctype IN ('C', 'R') THEN -1 ELSE 1 END  AS base_balance,
 <? if exists("includeFormatted") ?>
        formatDate(aropen_docdate) AS f_docdate,
        formatDate(aropen_duedate) AS f_duedate,
        formatMoney(aropen_amount) AS f_amount,
-       formatMoney(aropen_paid - (COALESCE(SUM(arapply_target_paid),0))) AS f_paid,
-       formatMoney((((aropen_amount-aropen_paid+COALESCE(SUM(arapply_target_paid),0))) *
-        CASE WHEN (aropen_doctype IN ('C', 'R')) THEN -1 ELSE 1 END)) AS f_balance,
+       formatMoney(aropen_paid - COALESCE(arapply_non_distributable_amount, 0)) AS f_paid,
+       formatMoney(((aropen_amount - COALESCE(arapply_distributable_amount, 0)) *
+                     CASE WHEN aropen_doctype IN ('C', 'R') THEN -1 ELSE 1 END AS f_balance,
 <? endif ?>
        cust_id, cust_number, cust_name,
        COALESCE(invchead_recurring_invchead_id IS NOT NULL, false) AS recurring,
@@ -254,25 +264,23 @@ SELECT aropen_id AS id,
        END AS aropen_duedate_qtforegroundrole,
        ccpay_id AS ccard_number_xtidrole,
        firstLine(aropen_notes) AS notes
-FROM aropen 
+  FROM aropen 
 <? if exists("incidentsOnly") ?>
-            JOIN incdt ON (incdt_aropen_id=aropen_id)
+  JOIN incdt ON (incdt_aropen_id=aropen_id)
 <? endif ?>
-            JOIN custinfo ON (aropen_cust_id=cust_id)
-            JOIN custtype ON (cust_custtype_id=custtype_id)
-	    LEFT OUTER JOIN custgrpitem ON (custgrpitem_cust_id=cust_id)
-            LEFT OUTER JOIN invchead ON ((aropen_docnumber=invchead_invcnumber)
+  JOIN custinfo ON (aropen_cust_id=cust_id)
+  JOIN custtype ON (cust_custtype_id=custtype_id)
+	LEFT OUTER JOIN custgrpitem ON (custgrpitem_cust_id=cust_id)
+  LEFT OUTER JOIN invchead ON ((aropen_docnumber=invchead_invcnumber)
                                    AND (aropen_doctype='I'))
-            LEFT OUTER JOIN cohead ON (invchead_ordernumber=cohead_number)
-            LEFT OUTER JOIN cmhead ON ((aropen_docnumber=cmhead_number)
+  LEFT OUTER JOIN cohead ON (invchead_ordernumber=cohead_number)
+  LEFT OUTER JOIN cmhead ON ((aropen_docnumber=cmhead_number)
                                    AND (aropen_doctype='C'))
-            LEFT OUTER JOIN arapply ON (((aropen_id=arapply_source_aropen_id)
-                             OR (aropen_id=arapply_target_aropen_id))
-                             AND (arapply_distdate>COALESCE(<? value("asofDate") ?>,current_date)))
-            LEFT OUTER JOIN payaropen ON (payaropen_aropen_id=aropen_id)
-            LEFT OUTER JOIN ccpay     ON (payaropen_ccpay_id=ccpay_id)
-            LEFT OUTER JOIN ccard     ON (ccpay_ccard_id=ccard_id)
-WHERE ((true)
+  LEFT OUTER JOIN arapply_summarized ON aropen_id IN (arapply_source_aropen_id, arapply_target_aropen_id)
+  LEFT OUTER JOIN payaropen ON (payaropen_aropen_id=aropen_id)
+  LEFT OUTER JOIN ccpay     ON (payaropen_ccpay_id=ccpay_id)
+  LEFT OUTER JOIN ccard     ON (ccpay_ccard_id=ccard_id)
+WHERE true
 <? if not exists("showClosed") ?>
   AND (aropen_docdate <= COALESCE(<? value("asofDate") ?>, current_date))
   AND (COALESCE(aropen_closedate, DATE(<? value("asofDate") ?>) + 1, current_date + 1) > COALESCE(<? value("asofDate") ?>, current_date)) 
@@ -303,16 +311,7 @@ WHERE ((true)
 <? if exists("endDueDate") ?>
   AND   (aropen_duedate <= <? value("endDueDate") ?>)
 <? endif ?>
-      )
-  GROUP BY id,                      altId,	            invchead_id,
-           aropen_docdate,          aropen_duedate,         aropen_doctype,         
-           aropen_docnumber,        aropen_amount,          
-           aropen_notes,            aropen_posted,          aropen_ordernumber,
-           aropen_paid,             aropen_open,            aropen_curr_id,
-           aropen_closedate,        aropen_curr_rate,       cmhead_id,
-           cust_id, 		    cust_number,            cust_name,
-           cohead_id,               ccpay_id,               ccard_number,
-           invchead_recurring_invchead_id,                  aropen_ponumber
+
 UNION
 SELECT -1,
        4 AS altId,


### PR DESCRIPTION
refactored the query so all arapply records are considered, not just those before a particular date. this allows for smarter calculation of applications as of specific dates.