### PR TITLE
issue #30486 - deleteitemlocdist perf

### DIFF
--- a/foundation-database/public/views/orderhead.sql
+++ b/foundation-database/public/views/orderhead.sql
@@ -1,44 +1,45 @@
 
 SELECT dropIfExists('view', 'orderhead');
 CREATE VIEW orderhead AS
-  SELECT DISTINCT * FROM (
-  SELECT pohead_id		AS orderhead_id,
-	 'PO'::text		AS orderhead_type,
-	 pohead_number		AS orderhead_number,
-	 pohead_status		AS orderhead_status,
-	 pohead_orderdate	AS orderhead_orderdate,
-	 (SELECT count(*)
-	   FROM poitem
-	   WHERE poitem_pohead_id=pohead_id) AS orderhead_linecount,
-	 pohead_vend_id		AS orderhead_from_id,
-	 vend_name		AS orderhead_from,
-	 NULL::int		AS orderhead_to_id,
-	 ''::text		AS orderhead_to,
-	 pohead_curr_id		AS orderhead_curr_id,
-	 pohead_agent_username	AS orderhead_agent_username,
-	 pohead_shipvia		AS orderhead_shipvia
-  FROM pohead LEFT OUTER JOIN vendinfo ON (pohead_vend_id=vend_id)
+
+  SELECT pohead.pohead_id AS orderhead_id,
+    'PO'::text AS orderhead_type,
+    pohead.pohead_number AS orderhead_number,
+    pohead.pohead_status AS orderhead_status,
+    pohead.pohead_orderdate AS orderhead_orderdate,
+    ( SELECT count(*) AS count
+           FROM poitem
+          WHERE poitem.poitem_pohead_id = pohead.pohead_id) AS orderhead_linecount,
+    pohead.pohead_vend_id AS orderhead_from_id,
+    ( SELECT vendinfo.vend_name
+           FROM vendinfo
+          WHERE pohead.pohead_vend_id = vendinfo.vend_id) AS orderhead_from,
+    NULL::integer AS orderhead_to_id,
+    ''::text AS orderhead_to,
+    pohead.pohead_curr_id AS orderhead_curr_id,
+    pohead.pohead_agent_username AS orderhead_agent_username,
+    pohead.pohead_shipvia AS orderhead_shipvia
+    FROM pohead
   UNION ALL
-  SELECT cohead_id		AS orderhead_id,
-	 'SO'::text		AS orderhead_type,
-  	 cohead_number		AS orderhead_number,
-	 cohead_status		AS orderhead_status,
-	 cohead_orderdate	AS orderhead_orderdate,
-	 (SELECT count(*)
-	  FROM coitem
-	  WHERE coitem_cohead_id=cohead_id) AS orderhead_linecount,
-	 NULL			AS orderhead_from_id,
-	 ''::text		AS orderhead_from,
-	 cohead_cust_id		AS orderhead_to_id,
-	 CASE 
-	   WHEN (length(cohead_shiptoname) > 0) THEN
-	     cohead_shiptoname
-	   ELSE cohead_billtoname
-	 END     		AS orderhead_to,
-	 cohead_curr_id		AS orderhead_curr_id,
-	 ''::text		AS orderhead_agent_username,
-	 cohead_shipvia		AS orderhead_shipvia
-  FROM cohead) AS data;
+  SELECT cohead.cohead_id AS orderhead_id,
+    'SO'::text AS orderhead_type,
+    cohead.cohead_number AS orderhead_number,
+    cohead.cohead_status AS orderhead_status,
+    cohead.cohead_orderdate AS orderhead_orderdate,
+    ( SELECT count(*) AS count
+           FROM coitem
+          WHERE coitem.coitem_cohead_id = cohead.cohead_id) AS orderhead_linecount,
+    NULL::integer AS orderhead_from_id,
+    ''::text AS orderhead_from,
+    cohead.cohead_cust_id AS orderhead_to_id,
+        CASE
+            WHEN length(cohead.cohead_shiptoname) > 0 THEN cohead.cohead_shiptoname
+            ELSE cohead.cohead_billtoname
+        END AS orderhead_to,
+    cohead.cohead_curr_id AS orderhead_curr_id,
+    ''::text AS orderhead_agent_username,
+    cohead.cohead_shipvia AS orderhead_shipvia
+    FROM cohead;
 
 REVOKE ALL ON TABLE orderhead FROM PUBLIC;
 GRANT  ALL ON TABLE orderhead TO GROUP xtrole;

--- a/foundation-database/public/views/orderitem.sql
+++ b/foundation-database/public/views/orderitem.sql
@@ -1,8 +1,9 @@
 
 SELECT dropIfExists('view', 'orderitem');
 CREATE VIEW orderitem AS
+
   SELECT poitem_id		AS orderitem_id,
-	 'PO'			AS orderitem_orderhead_type,
+	 'PO'::text			AS orderitem_orderhead_type,
 	 poitem_pohead_id	AS orderitem_orderhead_id,
 	 poitem_linenumber	AS orderitem_linenumber,
 	 poitem_status		AS orderitem_status,
@@ -18,12 +19,11 @@ CREATE VIEW orderitem AS
 	 poitem_freight		AS orderitem_freight,
 	 poitem_freight_received AS orderitem_freight_received,
 	 pohead_curr_id         AS orderitem_freight_curr_id
-
   FROM poitem LEFT OUTER JOIN pohead ON (poitem_pohead_id=pohead_id)
               LEFT OUTER JOIN uom ON (uom_name=poitem_vend_uom)
   UNION ALL
   SELECT coitem_id		AS orderitem_id,
-	 'SO'			AS orderitem_orderhead_type,
+	 'SO'::text			AS orderitem_orderhead_type,
 	 coitem_cohead_id	AS orderitem_orderhead_id,
 	 coitem_linenumber	AS orderitem_linenumber,
 	 coitem_status		AS orderitem_status,
@@ -42,21 +42,21 @@ CREATE VIEW orderitem AS
   FROM coitem
   UNION ALL
   SELECT quitem_id		AS orderitem_id,
-	 'QU'			AS orderitem_orderhead_type,
+	 'QU'::text			AS orderitem_orderhead_type,
 	 quitem_quhead_id	AS orderitem_orderhead_id,
 	 quitem_linenumber	AS orderitem_linenumber,
-	 'O'			AS orderitem_status,
+	 'O'::text			AS orderitem_status,
 	 quitem_itemsite_id	AS orderitem_itemsite_id,
 	 quitem_scheddate	AS orderitem_scheddate,
 	 quitem_qtyord		AS orderitem_qty_ordered,
-	 0			AS orderitem_qty_shipped,
-	 0			AS orderitem_qty_received,
+	 0::numeric			AS orderitem_qty_shipped,
+	 0::numeric			AS orderitem_qty_received,
 	 quitem_qty_uom_id	AS orderitem_qty_uom_id,
 	 quitem_qty_invuomratio	AS orderitem_qty_invuomratio,
 	 quitem_unitcost	AS orderitem_unitcost,
 	 basecurrid()		AS orderitem_unitcost_curr_id,
-	 NULL			AS orderitem_freight,
-	 NULL			AS orderitem_freight_received,
+	 NULL::numeric			AS orderitem_freight,
+	 NULL::numeric			AS orderitem_freight_received,
 	 basecurrid()		AS orderitem_freight_curr_id
   FROM quitem;
 


### PR DESCRIPTION
Remove unneeded `SELECT DISTINCT *` on orderhead. 
Move `LEFT OUTER JOIN vendinfo` to column sub query improves performance with `private-extensions` version from 7.5 seconds to 500 ms.