### PR TITLE
Issue #19378: Drop duplicate indexes

### DIFF
--- a/foundation-database/manifest.js
+++ b/foundation-database/manifest.js
@@ -1096,6 +1096,7 @@
     "public/indexes/voheadtax.sql",
     "public/indexes/voitemtax.sql",
     "public/indexes/womatlpost.sql",
+    "public/indexes/drop_duplicates.sql",
 
     "public/trigger_functions/accnt.sql",
     "public/trigger_functions/addr.sql",

--- a/foundation-database/public/indexes/drop_duplicates.sql
+++ b/foundation-database/public/indexes/drop_duplicates.sql
@@ -1,0 +1,12 @@
+/*  
+   Remove duplicate Indexes created in 440 schema and typically recreated in
+   subsequent constraints or scripts in the manifest
+*/
+
+DROP INDEX IF EXISTS item_number_idx;
+DROP INDEX IF EXISTS cohead_number_idx;
+DROP INDEX IF EXISTS vend_number_idx;
+DROP INDEX IF EXISTS cust_number_idx;
+ALTER TABLE public.ipsitemchar DROP CONSTRAINT IF EXISTS ipsitemchar_ipsitemchar_ipsitem_id_key1;
+DROP INDEX IF EXISTS apselect_apselect_apopen_id_idx;
+


### PR DESCRIPTION
Duplicates typically came from the 440 schema, so added a drop script rather than just removing from 440 _schema in order to effect change in upgrade scripts.