### PR TITLE
Fixes: #30663 Force all pg connections to get a valid search path by calling destroy() on any pg connection pool client connections that generated an error in the database.

### DIFF
--- a/node-datasource/lib/ext/datasource.js
+++ b/node-datasource/lib/ext/datasource.js
@@ -27,12 +27,12 @@ Backbone:true, _:true, X:true, __dirname:true, exports:true, module: true */
        * We make use of plv8's `SET plv8.start_proc = 'xt.js_init' feature.
        * This is only called the FIRST time a plv8 function is called for a
        * connection. Because of this, if a connection, when added to the pool
-       * happens to cause an error in the database during its first query, all
-       * of the steps we do for a persistent client connection in
-       * `xt.js_init();` are rolled back. The main thing we setup is the
-       * `search_path`. If an error happens on the first query for this
+       * happens to cause an error in the database during its first transaction
+       * that uses plv8, all of the steps we do for a persistent client
+       * connection in `xt.js_init();` are rolled back. The main thing we setup
+       * is the `search_path`. If an error happens on the first query for this
        * connection, the `search_path` will not be set the next time the pool's
-       * conneciton is used for a query.
+       * connection is used for a query.
        *
        * Because of this, on any emitted errors below in `connected()`, we
        * destroy that client from the pool.

--- a/test/database/dblib.js
+++ b/test/database/dblib.js
@@ -60,11 +60,11 @@
       if (_.isFunction(done)) { done(); }
     });
   };
-        
+
   /** create an application user from a { user: name, password: val, ...} */
   exports.createUser = function (creds, done) {
     var context = _.extend({}, adminCred, { parameters: [ creds.user ] }),
-        cu = function (done) {
+        cu = function () {
           var createSql = 'select createUser($1, false) as result;';
           datasource.query(createSql, context, function (err, res) {
             if (err) {
@@ -74,19 +74,19 @@
             } else {
               assert.equal(res.rowCount, 1);
             }
-            if (_.isFunction(done)) { done(); }
+            sp();
           });
         },
-        sp = function (done) {
+        sp = function () {
           var passwdSql = "alter user \"" + creds.user +
                           "\" with password '" + creds.password + "';";
           datasource.query(passwdSql, adminCred, function (err, res) {
 //          assert.isNull(err, 'expect no error changing the user password');
 //          assert.isNull(res);
-            if (_.isFunction(done)) { done(); }
+            sr();
           });
         },
-        sr = function (done) {
+        sr = function () {
           var xtroleSql = 'alter group xtrole add user "' + creds.user + '";';
           datasource.query(xtroleSql, adminCred, function (err, res) {
 //          assert.isNull(err, 'expect no error adding user to xtrole');
@@ -95,36 +95,34 @@
           });
         };
     cu();
-    sp();
-    sr(done);
   };
 
   /** @param userdesc {Object,String} either a credentials object or a string */
   exports.deleteUser = function (userdesc, done) {
     var username = userdesc.user || userdesc,
         context  = _.extend({}, adminCred, { parameters: [ username ] }),
-        rgp = function (done) {
+        rgp = function () {
           var sql = 'delete from usrgrp where usrgrp_username = $1;';
           datasource.query(sql, context, function (err, res) {
             assert.isNull(err, 'revoking ' + username + ' usrgrp should work');
-            if (_.isFunction(done)) { done(); }
+            rup();
           });
         },
-        rup = function (done) {
+        rup = function () {
           var sql = 'delete from usrpriv where usrpriv_username = $1;';
           datasource.query(sql, context, function (err, res) {
             assert.isNull(err, 'revoking ' + username + ' usrpriv should work');
-            if (_.isFunction(done)) { done(); }
+            dxtu();
           });
         },
-        dxtu = function (done) {
+        dxtu = function () {
           var sql = 'delete from xt.usrlite where usr_username = $1;';
           datasource.query(sql, context, function (err, res) {
             assert.isNull(err, 'delete ' + username + ' xt.userlite should work');
-            if (_.isFunction(done)) { done(); }
+            du();
           });
         },
-        du = function (done) {
+        du = function () {
           var sql = 'drop user "' + username + '";';
           datasource.query(sql, adminCred, function (err, res) {
             if (err) {
@@ -134,11 +132,6 @@
           });
         };
     rgp();
-    rup();
-    dxtu();
-    du();
-
-    if (_.isFunction(done)) { done(); }
   };
 
   /**

--- a/test/database/functions/importbankreccleared.js
+++ b/test/database/functions/importbankreccleared.js
@@ -15,7 +15,6 @@ var _      = require("underscore"),
                      ],
         bankrec, bankrecimport, metric
         ;
-    this.timeout(20000);
 
     it("needs to save some metrics", function (done) {
      var sql = dblib.getMetricsQry(metricList);
@@ -177,7 +176,7 @@ var _      = require("underscore"),
       });
     });
 
-    it.skip("should succeed with various bankrecimports", function (done) {
+    it("should succeed with various bankrecimports", function (done) {
       var sql  = "select importBankrecCleared($1) as result;",
           i    = 0;
       _.each(bankrecimport, function (row) {

--- a/test/database/functions/importbankreccleared.js
+++ b/test/database/functions/importbankreccleared.js
@@ -15,6 +15,7 @@ var _      = require("underscore"),
                      ],
         bankrec, bankrecimport, metric
         ;
+    this.timeout(20000);
 
     it("needs to save some metrics", function (done) {
      var sql = dblib.getMetricsQry(metricList);
@@ -176,7 +177,7 @@ var _      = require("underscore"),
       });
     });
 
-    it("should succeed with various bankrecimports", function (done) {
+    it.skip("should succeed with various bankrecimports", function (done) {
       var sql  = "select importBankrecCleared($1) as result;",
           i    = 0;
       _.each(bankrecimport, function (row) {

--- a/test/database/functions/site.js
+++ b/test/database/functions/site.js
@@ -15,6 +15,10 @@ var _     = require("underscore"),
         whsinfo
         ;
 
+    it('should delete test user if it exists', function (done) {
+      dblib.deleteUser(casualCred, done);
+    });
+
     it('should create a test user', function (done) {
       dblib.createUser(casualCred, done);
     });


### PR DESCRIPTION
I suspect this may be the root cause of some of the nondeterministic errors we have been seeing in tests.