### PR TITLE
Issue #30782: Package enabling and disabling errors

### DIFF
--- a/foundation-database/manifest.js
+++ b/foundation-database/manifest.js
@@ -71,6 +71,7 @@
     "public/functions/_docinfo.sql",
     "public/functions/_gettargetdocument.sql",
     "public/functions/_normalizeversion.sql",
+    "public/functions/_setpackageisenabled.sql",
     "public/functions/acknowledgemessage.sql",
     "public/functions/actcost.sql",
     "public/functions/addrusecount.sql",

--- a/foundation-database/public/functions/_setpackageisenabled.sql
+++ b/foundation-database/public/functions/_setpackageisenabled.sql
@@ -1,0 +1,74 @@
+CREATE OR REPLACE FUNCTION _setPackageIsEnabled(pName TEXT, pEnabled BOOLEAN) RETURNS INTEGER AS $$
+-- Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
+-- See www.xtuple.com/CPAL for the full text of the software license.
+DECLARE
+  _i      INTEGER := 0;
+  _tabs   TEXT[] := ARRAY['cmd',  'cmdarg', 'image',  'metasql',
+                          'priv', 'report', 'script', 'uiform', 'dict'];
+  _table  TEXT;
+  _trigger RECORD;
+
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pkghead WHERE LOWER(pkghead_name) = LOWER(pName)) THEN
+    RAISE EXCEPTION '_setPackageIsEnabled could not find an extension named % [xtuple: _setPackageIsEnabled, -1, %]',
+                    pName, pName;
+  END IF;
+
+  FOR _i IN ARRAY_LOWER(_tabs,1)..ARRAY_UPPER(_tabs,1) LOOP
+    BEGIN
+      EXECUTE format('ALTER TABLE IF EXISTS %I.%I %s INHERIT public.%I;',
+                     LOWER(pName), 'pkg' || _tabs[_i],
+                     CASE WHEN pEnabled THEN '' ELSE 'NO' END, _tabs[_i]);
+    EXCEPTION WHEN duplicate_table OR undefined_table THEN -- ignore the error
+    END;
+  END LOOP;
+
+  FOR _trigger IN
+    SELECT tabn.nspname, relname, tgname
+      FROM pg_trigger   t
+      JOIN pg_class     c    ON tgrelid      = c.oid AND relkind = 'r'
+      JOIN pg_namespace tabn ON relnamespace = tabn.oid
+      JOIN pg_proc      p    ON tgfoid       = p.oid
+      JOIN pg_namespace trin ON pronamespace = trin.oid
+     WHERE LOWER(trin.nspname) = LOWER(pName)
+  LOOP
+    EXECUTE format('ALTER TABLE %I.%I %s TRIGGER %I;',
+                   _trigger.nspname, _trigger.relname,
+                   CASE WHEN pEnabled THEN 'ENABLE' ELSE 'DISABLE' END,
+                   _trigger.tgname);
+  END LOOP;
+
+  FOR _table IN
+     SELECT DISTINCT relname
+       FROM pg_class
+       JOIN pg_namespace n ON relnamespace = n.oid
+      WHERE relkind = 'r'
+        AND nspname = LOWER(pName)
+  LOOP
+    EXECUTE format('ALTER TABLE %I.%I %s TRIGGER ALL;', LOWER(pName), _table,
+                   CASE WHEN pEnabled THEN 'ENABLE' ELSE 'DISABLE' END);
+  END LOOP;
+
+  RETURN 0;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION _setPackageIsEnabled(pId INTEGER, pEnabled BOOLEAN)
+  RETURNS INTEGER AS $$
+-- Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
+-- See www.xtuple.com/CPAL for the full text of the software license.
+DECLARE
+  _result INTEGER;
+
+BEGIN
+  SELECT _setPackageIsEnabled(pkghead_name, pEnabled) INTO _result
+    FROM pkghead
+   WHERE pkghead_id = pId;
+  IF _result IS NULL THEN
+    RAISE EXCEPTION '_setPackageIsEnabled could not find an extension with id % [xtuple: _setPackageIsEnabled, -2, %]',
+                    pId, pId;
+  END IF;
+
+  RETURN _result;
+END;
+$$ LANGUAGE plpgsql;

--- a/foundation-database/public/functions/disablepackage.sql
+++ b/foundation-database/public/functions/disablepackage.sql
@@ -14,7 +14,7 @@ BEGIN
   END IF;
 
   FOR _i IN ARRAY_LOWER(_tabs,1)..ARRAY_UPPER(_tabs,1) LOOP
-    EXECUTE 'ALTER TABLE ' || ppkgname || '.pkg' || _tabs[_i] ||
+    EXECUTE 'ALTER TABLE IF EXISTS ' || ppkgname || '.pkg' || _tabs[_i] ||
             ' NO INHERIT public.' || _tabs[_i] || ';';
   END LOOP;
 
@@ -28,7 +28,7 @@ BEGIN
      WHERE nspname=ppkgname
      AND typname = 'trigger'
   LOOP
-    EXECUTE format('ALTER TABLE %s DISABLE TRIGGER %s', _trigs.tbl, _trigs.tgname);
+    EXECUTE format('ALTER TABLE %I DISABLE TRIGGER %I', _trigs.tbl, _trigs.tgname);
   END LOOP;
 
   RETURN 0;

--- a/foundation-database/public/functions/disablepackage.sql
+++ b/foundation-database/public/functions/disablepackage.sql
@@ -1,57 +1,14 @@
-CREATE OR REPLACE FUNCTION disablePackage(TEXT) RETURNS INTEGER AS $$
+DROP FUNCTION IF EXISTS disablePackage(TEXT);
+DROP FUNCTION IF EXISTS disablePackage(INTEGER);
+
+CREATE OR REPLACE FUNCTION disablePackage(pName TEXT) RETURNS INTEGER AS $$
 -- Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
-DECLARE
-  ppkgname ALIAS FOR $1;
-  _i       INTEGER := 0;
-  _tabs    TEXT[] := ARRAY['cmd',  'cmdarg', 'image',  'metasql',
-                           'priv', 'report', 'script', 'uiform', 'dict'];
-  _trigs   RECORD;
+  SELECT _setPackageIsEnabled(pName, false);
+$$ LANGUAGE sql;
 
-BEGIN
-  IF (version() < 'PostgreSQL 8.2') THEN
-    RETURN -1;
-  END IF;
-
-  FOR _i IN ARRAY_LOWER(_tabs,1)..ARRAY_UPPER(_tabs,1) LOOP
-    EXECUTE 'ALTER TABLE IF EXISTS ' || ppkgname || '.pkg' || _tabs[_i] ||
-            ' NO INHERIT public.' || _tabs[_i] || ';';
-  END LOOP;
-
--- Also find and disable schema package triggers
-  FOR _trigs IN
-     SELECT tgrelid::regclass AS tbl, tgname
-     FROM pg_proc
-      JOIN pg_namespace ON (pronamespace=pg_namespace.oid)
-      JOIN pg_type ON (prorettype=pg_type.oid)
-      JOIN pg_trigger ON (tgfoid=pg_proc.oid)
-     WHERE nspname=ppkgname
-     AND typname = 'trigger'
-  LOOP
-    EXECUTE format('ALTER TABLE %I DISABLE TRIGGER %I', _trigs.tbl, _trigs.tgname);
-  END LOOP;
-
-  RETURN 0;
-END;
-$$
-LANGUAGE 'plpgsql';
-
-CREATE OR REPLACE FUNCTION disablePackage(INTEGER) RETURNS INTEGER AS $$
+CREATE OR REPLACE FUNCTION disablePackage(pId INTEGER) RETURNS INTEGER AS $$
 -- Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
-DECLARE
-  ppkgheadid    ALIAS FOR $1;
-  _pkgname      TEXT;
-
-BEGIN
-  SELECT pkghead_name INTO _pkgname
-  FROM pkghead
-  WHERE (pkghead_id=ppkgheadid);
-  IF (NOT FOUND) THEN
-    RETURN -2;
-  END IF;
-
-  RETURN disablePackage(_pkgname);
-END;
-$$
-LANGUAGE 'plpgsql';
+  SELECT _setPackageIsEnabled(pId, false);
+$$ LANGUAGE sql;

--- a/foundation-database/public/functions/enablepackage.sql
+++ b/foundation-database/public/functions/enablepackage.sql
@@ -1,56 +1,14 @@
-CREATE OR REPLACE FUNCTION enablePackage(TEXT) RETURNS INTEGER AS $$
+DROP FUNCTION IF EXISTS enablePackage(TEXT);
+DROP FUNCTION IF EXISTS enablePackage(INTEGER);
+
+CREATE OR REPLACE FUNCTION enablePackage(pName TEXT) RETURNS INTEGER AS $$
 -- Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
-DECLARE
-  ppkgname  ALIAS FOR $1;
-  _i        INTEGER := 0;
-  _tabs     TEXT[] := ARRAY['cmd',  'cmdarg', 'image',  'metasql',
-                            'priv', 'report', 'script', 'uiform', 'dict'];
-  _trigs   RECORD;
-BEGIN
-  IF (version() < 'PostgreSQL 8.2') THEN
-    RETURN -1;
-  END IF;
+  SELECT _setPackageIsEnabled(pName, true);
+$$ LANGUAGE sql;
 
-  FOR _i IN ARRAY_LOWER(_tabs,1)..ARRAY_UPPER(_tabs,1) LOOP
-    EXECUTE 'ALTER TABLE IF EXISTS ' || ppkgname || '.pkg' || _tabs[_i] ||
-            ' INHERIT public.' || _tabs[_i] || ';';
-  END LOOP;
-
--- Also find and ENable package triggers
-  FOR _trigs IN
-     SELECT tgrelid::regclass AS tbl, tgname
-     FROM pg_proc
-      JOIN pg_namespace ON (pronamespace=pg_namespace.oid)
-      JOIN pg_type ON (prorettype=pg_type.oid)
-      JOIN pg_trigger ON (tgfoid=pg_proc.oid)
-     WHERE nspname=ppkgname
-     AND typname = 'trigger'
-  LOOP
-    EXECUTE format('ALTER TABLE %I ENABLE TRIGGER %I', _trigs.tbl, _trigs.tgname);
-  END LOOP;
-
-  RETURN 0;
-END;
-$$
-LANGUAGE 'plpgsql';
-
-CREATE OR REPLACE FUNCTION enablePackage(INTEGER) RETURNS INTEGER AS $$
+CREATE OR REPLACE FUNCTION enablePackage(pId INTEGER) RETURNS INTEGER AS $$
 -- Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
-DECLARE
-  ppkgheadid    ALIAS FOR $1;
-  _pkgname      TEXT;
-
-BEGIN
-  SELECT pkghead_name INTO _pkgname
-  FROM pkghead
-  WHERE (pkghead_id=ppkgheadid);
-  IF (NOT FOUND) THEN
-    RETURN -2;
-  END IF;
-
-  RETURN enablePackage(_pkgname);
-END;
-$$
-LANGUAGE 'plpgsql';
+  SELECT _setPackageIsEnabled(pId, true);
+$$ LANGUAGE sql;

--- a/foundation-database/public/functions/enablepackage.sql
+++ b/foundation-database/public/functions/enablepackage.sql
@@ -13,7 +13,7 @@ BEGIN
   END IF;
 
   FOR _i IN ARRAY_LOWER(_tabs,1)..ARRAY_UPPER(_tabs,1) LOOP
-    EXECUTE 'ALTER TABLE ' || ppkgname || '.pkg' || _tabs[_i] ||
+    EXECUTE 'ALTER TABLE IF EXISTS ' || ppkgname || '.pkg' || _tabs[_i] ||
             ' INHERIT public.' || _tabs[_i] || ';';
   END LOOP;
 
@@ -27,7 +27,7 @@ BEGIN
      WHERE nspname=ppkgname
      AND typname = 'trigger'
   LOOP
-    EXECUTE format('ALTER TABLE %s ENABLE TRIGGER %s', _trigs.tbl, _trigs.tgname);
+    EXECUTE format('ALTER TABLE %I ENABLE TRIGGER %I', _trigs.tbl, _trigs.tgname);
   END LOOP;
 
   RETURN 0;

--- a/test/database/functions/_setpackageisenabled.js
+++ b/test/database/functions/_setpackageisenabled.js
@@ -1,0 +1,186 @@
+var _      = require("underscore"),
+    assert = require('chai').assert,
+    dblib  = require('../dblib');
+
+(function () {
+  "use strict";
+
+  describe('_setPackageIsEnabled()', function () {
+
+    var datasource = dblib.datasource,
+        adminCred  = dblib.generateCreds(),
+        testPkgName = 'testPackage' + Date.now(), //Date.now().valueOf()?
+        testPkgId
+        ;
+
+    it("needs a package to test with", function (done) {
+      var sql = "SELECT createpkgschema($1, 'test enabling and disabling of extension schemas') AS result;",
+          cred = _.extend({}, adminCred, { parameters: [ testPkgName ]});
+      datasource.query(sql, cred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        done();
+      });
+    });
+
+    it("needs the pkghead_id", function (done) {
+      var sql = "SELECT pkghead_id FROM pkghead WHERE pkghead_name = LOWER($1);",
+          cred = _.extend({}, adminCred, { parameters: [ testPkgName ]});
+      datasource.query(sql, cred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        testPkgId = res.rows[0].pkghead_id;
+        done();
+      });
+    });
+
+    it("needs an extra table", function (done) {
+      var sql = "SELECT xt.create_table('testTab', $1) AS result;",
+          cred = _.extend({}, adminCred, { parameters: [ testPkgName ]});
+      datasource.query(sql, cred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        done();
+      });
+    });
+
+    it("test table needs a column", function (done) {
+      var sql = "SELECT xt.add_column('testTab', 'testTab_integer', 'INTEGER', NULL, $1) AS result;",
+          cred = _.extend({}, adminCred, { parameters: [ testPkgName ]});
+      datasource.query(sql, cred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        done();
+      });
+    });
+
+    it("needs a trigger function", function (done) {
+      var sql = "CREATE OR REPLACE FUNCTION _publicTrigger() RETURNS TRIGGER AS $$ BEGIN RAISE NOTICE 'entered with %', TG_OP; RETURN NEW; END; $$ LANGUAGE plpgsql;";
+      datasource.query(sql, adminCred, function (err, res) {
+        assert.isNull(err);
+        done();
+      });
+    });
+
+    it("needs a trigger", function (done) {
+      var sql = "CREATE TRIGGER publicTrigger"
+              + " BEFORE INSERT ON " + testPkgName + ".testTab"
+              + " FOR EACH ROW EXECUTE PROCEDURE _publicTrigger();";
+      datasource.query(sql, adminCred, function (err, res) {
+        assert.isNull(err);
+        done();
+      });
+    });
+
+    it("should fail with non-existent package name", function (done) {
+      var sql = "select _setPackageIsEnabled('thispackagedoesnotexist', true) as result;";
+      datasource.query(sql, adminCred, function (err, res) {
+        assert.isNotNull(err);
+        done();
+      });
+    });
+
+    it("should fail with non-existent package id", function (done) {
+      var sql = "SELECT _setPackageIsEnabled(-1, TRUE) AS result;";
+      datasource.query(sql, adminCred, function (err, res) {
+        assert.isNotNull(err);
+        done();
+      });
+    });
+
+    it("should disable a package by name", function (done) {
+      var sql  = "SELECT _setPackageIsEnabled($1, FALSE) AS result;",
+          cred = _.extend({}, adminCred, { parameters: [ testPkgName ]});
+      datasource.query(sql, cred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        done();
+      });
+    });
+
+    it("should enable a package by name", function (done) {
+      var sql  = "SELECT _setPackageIsEnabled($1, TRUE) AS result;",
+          cred = _.extend({}, adminCred, { parameters: [ testPkgName ]});
+      datasource.query(sql, cred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        done();
+      });
+    });
+
+    it("should disable a package by id", function (done) {
+      var sql  = "SELECT _setPackageIsEnabled($1::INTEGER, FALSE) AS result;",
+          cred = _.extend({}, adminCred, { parameters: [ testPkgId ]});
+      datasource.query(sql, cred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        done();
+      });
+    });
+
+    it("should disable an already-disabled package by id", function (done) {
+      var sql  = "SELECT _setPackageIsEnabled($1::INTEGER, TRUE) AS result;",
+          cred = _.extend({}, adminCred, { parameters: [ testPkgId ]});
+      datasource.query(sql, cred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        done();
+      });
+    });
+
+    it("should disable an already-disabled package by name", function (done) {
+      var sql  = "SELECT _setPackageIsEnabled($1, TRUE) AS result;",
+          cred = _.extend({}, adminCred, { parameters: [ testPkgName ]});
+      datasource.query(sql, cred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        done();
+      });
+    });
+
+    it.skip("should not execute the public trigger when the package is disabled");
+    it.skip("should not execute a package trigger on a public table when the package is disabled");
+
+    it("should enable a package by id", function (done) {
+      var sql  = "SELECT _setPackageIsEnabled($1::INTEGER, TRUE) AS result;",
+          cred = _.extend({}, adminCred, { parameters: [ testPkgId ]});
+      datasource.query(sql, cred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        done();
+      });
+    });
+
+    it("should enable an already-enabled package by id", function (done) {
+      var sql  = "SELECT _setPackageIsEnabled($1::INTEGER, TRUE) AS result;",
+          cred = _.extend({}, adminCred, { parameters: [ testPkgId ]});
+      datasource.query(sql, cred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        done();
+      });
+    });
+
+    it("should enable an already-enabled package by name", function (done) {
+      var sql  = "SELECT _setPackageIsEnabled($1, TRUE) AS result;",
+          cred = _.extend({}, adminCred, { parameters: [ testPkgName ]});
+      datasource.query(sql, cred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        done();
+      });
+    });
+
+    it("need to clean up afterward", function (done) {
+      var sql  = "SELECT deletePackage($1) AS result;",
+          cred = _.extend({}, adminCred, { parameters: [ testPkgId ]});
+      datasource.query(sql, cred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        done();
+      });
+    });
+
+  });
+
+}());


### PR DESCRIPTION
This resolves the errors reported in the issue plus another issue found in testing.
I am now getting a new error when attempting to enable/reenable the `assetmaint` package
 ```
ERROR:  relation "dict" would be inherited from more than once
CONTEXT:  SQL statement "ALTER TABLE IF EXISTS assetmaint.pkgdict INHERIT public.dict;"

```

No other package is presenting this.  The assetmaint.pkgdict table looks subtly different in pgAdmin but not sure where pkgdict is created no not sure why this particular package has an issue