### PR TITLE
Fixes Issue #30663 Call done(err) instead, which destroy's the client and removed it from the pool.

### DIFF
--- a/node-datasource/lib/ext/datasource.js
+++ b/node-datasource/lib/ext/datasource.js
@@ -20,28 +20,6 @@ Backbone:true, _:true, X:true, __dirname:true, exports:true, module: true */
 
       creds : {},
 
-      /**
-       * The package, `node-postgres`, we use, exposed as `X.pg` maintains a
-       * connection pool to the database server, defaulting to 10 connections.
-       *
-       * We make use of plv8's `SET plv8.start_proc = 'xt.js_init' feature.
-       * This is only called the FIRST time a plv8 function is called for a
-       * connection. Because of this, if a connection, when added to the pool
-       * happens to cause an error in the database during its first transaction
-       * that uses plv8, all of the steps we do for a persistent client
-       * connection in `xt.js_init();` are rolled back. The main thing we setup
-       * is the `search_path`. If an error happens on the first query for this
-       * connection, the `search_path` will not be set the next time the pool's
-       * connection is used for a query.
-       *
-       * Because of this, on any emitted errors below in `connected()`, we
-       * destroy that client from the pool.
-       */
-      destroyClientFromPool: function (client) {
-        client.destroying = true;
-        X.pg.pools.all[JSON.stringify(this.creds)].destroy(client);
-      },
-
       getAdminCredentials: function (organization) {
         return {
           user: X.options.databaseServer.user,
@@ -224,7 +202,6 @@ Backbone:true, _:true, X:true, __dirname:true, exports:true, module: true */
           if (err) {
             // Set activeQuery for error event handler above.
             that.activeQuery = client.activeQuery ? client.activeQuery.text : 'unknown. See PostgreSQL log.';
-            that.destroyClientFromPool(client);
           }
 
           if (client.status && client.status.length) {
@@ -269,7 +246,33 @@ Backbone:true, _:true, X:true, __dirname:true, exports:true, module: true */
           }
 
           // Release the client from the pool.
-          done();
+          if (err) {
+            /**
+             * The package, `node-postgres`, we use maintains a connection pool
+             * to the database server, defaulting to 10 connections.
+             *
+             * We make use of plv8's `SET plv8.start_proc = 'xt.js_init'
+             * feature for those connections. This is only called the FIRST time
+             * a plv8 function is called for a connection. Because of this, if a
+             * connection, when added to the pool happens to cause an error in
+             * the database during its first transaction that uses plv8, all of
+             * the steps we do for a persistent client connection in
+             * `xt.js_init();` are rolled back. The main thing we setup is the
+             * `search_path`. If an error happens on the first query for this
+             * connection, the `search_path` will not be set the next time the
+             * pool's connection is used for a query.
+             *
+             * Because of this, on any emitted errors below in `connected()`, we
+             * destroy that client from the pool.
+             */
+
+            // Set flag so we don't use this client above before it's removed.
+            client.destroying = true;
+
+            done(err);
+          } else {
+            done();
+          }
 
           // Call the call back.
           callback(err, result);

--- a/node-datasource/lib/ext/datasource.js
+++ b/node-datasource/lib/ext/datasource.js
@@ -270,6 +270,14 @@ Backbone:true, _:true, X:true, __dirname:true, exports:true, module: true */
             client.destroying = true;
 
             done(err);
+
+            // Now that the client has been destroyed, for the pool to function
+            // correctly, we need to add one back to take it's place.
+            // @see: https://github.com/brianc/node-postgres/issues/1460
+            X.pg.pools.all[JSON.stringify(that.creds)].acquire(function (err, newClient) {
+              // But we don't actually need it, so release it back to the pool.
+              X.pg.pools.all[JSON.stringify(that.creds)].release(newClient);
+            });
           } else {
             done();
           }

--- a/node-datasource/lib/ext/datasource.js
+++ b/node-datasource/lib/ext/datasource.js
@@ -272,18 +272,22 @@ Backbone:true, _:true, X:true, __dirname:true, exports:true, module: true */
             done(err);
 
             // Now that the client has been destroyed, for the pool to function
-            // correctly, we need to add one back to take it's place.
+            // correctly, we need to add one back to take its place.
             // @see: https://github.com/brianc/node-postgres/issues/1460
-            X.pg.pools.all[JSON.stringify(that.creds)].acquire(function (err, newClient) {
+            X.pg.pools.all[JSON.stringify(that.creds)].acquire(function (newErr, newClient) {
               // But we don't actually need it, so release it back to the pool.
               X.pg.pools.all[JSON.stringify(that.creds)].release(newClient);
+
+              // Once the client has been added to the pool, call the callback.
+              callback(err, result);
             });
           } else {
             done();
+
+            // Call the callback.
+            callback(err, result);
           }
 
-          // Call the call back.
-          callback(err, result);
         };
 
         // node-postgres supports parameters as a second argument. These will be options.parameters


### PR DESCRIPTION
The last fix disconnected the client and removed it from the pool by calling `X.pg.pools.all[JSON.stringify(this.creds)].destroy(client);`. However, the `done()` callback was still called below that, which reconnected a new client and threw off the pool count. Line 272 here:
https://github.com/xtuple/xtuple/blob/6a2718719596b1e03ac83f47d07ac9d51f56de94/node-datasource/lib/ext/datasource.js#L227-L272

That lead to the active pg connections building until the pg server hit 100 connections and stopped accepting any more.

By calling `done(err)` instead of `X.pg.pools.all[JSON.stringify(this.creds)].destroy(client);`, `destroy()` get called anyways, which was the original goal of the last commit. The call happens here:
https://github.com/brianc/node-postgres/blob/v0.14.1/lib/pool.js#L109-L113
