### PR TITLE
Issue #19555: Allow Quotes (and Return Auths) to be attached as documents

### DIFF
--- a/foundation-database/public/patches/populate_source.sql
+++ b/foundation-database/public/patches/populate_source.sql
@@ -467,7 +467,7 @@ select createDoctype(27, --pDocAssNum
                      'rahead_number', --pNumber
                      'cust_name', --pName
                      'firstline(rahead_notes)', --pDesc
-                     '', --pWidget
+                     'core', --pWidget
                      'join custinfo on rahead_cust_id = cust_id', --pJoin
                      'rahead_id', --pParam
                      'returnAuthorization', --pUi
@@ -502,7 +502,7 @@ select createDoctype(29, --pDocAssNum
                      'quhead_number', --pNumber
                      'cust_name', --pName
                      'firstline(quhead_ordercomments)', --pDesc
-                     '', --pWidget
+                     'core', --pWidget
                      'join custinfo on quhead_cust_id = cust_id', --pJoin
                      'quhead_id', --pParam
                      'salesOrder', --pUi


### PR DESCRIPTION
requires xtuple/qt-client#1775 otherwise a segfault occurs in the document assignment widget