### PR TITLE
Issue #30799: Improve relationship between voided voucher and CM tax

### DIFF
--- a/foundation-database/public/functions/updatememotax.sql
+++ b/foundation-database/public/functions/updatememotax.sql
@@ -1,4 +1,4 @@
-DROP FUNCTION IF EXISTS updatememotax(text, text, integer, integer, date, integer, numeric);
+DROP FUNCTION IF EXISTS updatememotax(text, text, integer, integer, date, integer, numeric, numeric);
 
 CREATE OR REPLACE FUNCTION updatememotax(
     pDocSource text,
@@ -8,10 +8,11 @@ CREATE OR REPLACE FUNCTION updatememotax(
     pDate date,
     pCurr integer,
     pAmount numeric,
-    pCurrRate NUMERIC DEFAULT NULL
+    pCurrRate NUMERIC DEFAULT NULL,
+    pAutoOverride BOOLEAN DEFAULT FALSE
     )
   RETURNS numeric AS $func$
--- Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
+-- Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
 DECLARE
    _table       text;
@@ -25,15 +26,15 @@ DECLARE
    _subtotal	numeric;
    _delSql      text := $$DELETE FROM %s WHERE taxhist_parent_id = %s; $$;
    _sql         text := $$INSERT INTO %s (taxhist_basis, taxhist_percent,
-                                          taxhist_amount,taxhist_docdate, 
-                                          taxhist_tax_id, taxhist_tax, 
+                                          taxhist_amount,taxhist_docdate,
+                                          taxhist_tax_id, taxhist_tax,
                                           taxhist_taxtype_id, taxhist_parent_id,
                                           taxhist_curr_id, taxhist_curr_rate, taxhist_distdate  )
 	                   VALUES (0, 0, 0, '%s'::DATE, %s, %s, %s, %s, %s, %s, '%s'::DATE); $$;
    _revsql      text := $$INSERT INTO %s (taxhist_basis, taxhist_percent,
-                                          taxhist_amount,taxhist_docdate, 
-                                          taxhist_tax_id, taxhist_tax, 
-                                          taxhist_taxtype_id, taxhist_parent_id, 
+                                          taxhist_amount,taxhist_docdate,
+                                          taxhist_tax_id, taxhist_tax,
+                                          taxhist_taxtype_id, taxhist_parent_id,
                                           taxhist_reverse_charge)
 	                   VALUES (0, 0, 0, '%s'::DATE, %s, (%s * -1), %s, %s, TRUE); $$;
 BEGIN
@@ -42,18 +43,18 @@ BEGIN
      _table = 'apopentax';
      IF (pDocType = 'D') THEN
        _sense = -1;
-     END IF;  
+     END IF;
 -- A/R memos
    ELSIF (pDocSource = 'AR') THEN
      _table = 'aropentax';
      IF (pDocType = 'C') THEN
        _sense = -1;
-     END IF;  
+     END IF;
    ELSE
      RAISE EXCEPTION 'Invalid memo type %', pDocSource;
    END IF;
 
-   EXECUTE format(_delSql, _table, pMemoid);   
+   EXECUTE format(_delSql, _table, pMemoid);
 
    -- Get Tax Adjustment Type(s) from configuration (auto-tax only)
    <<taxtypes>>
@@ -61,7 +62,7 @@ BEGIN
      SELECT DISTINCT COALESCE(taxass_taxtype_id, getadjustmenttaxtypeid()) AS taxass_taxtype_id
      FROM tax
      JOIN taxass ON (tax_id=taxass_tax_id)
-     WHERE ((taxass_memo_apply)
+     WHERE ((CASE WHEN pAutoOverride THEN TRUE ELSE taxass_memo_apply END)
        AND (taxass_taxtype_id = getadjustmenttaxtypeid()
               OR taxass_taxtype_id IS NULL)
       AND  (taxass_taxzone_id = ptaxzone))
@@ -74,34 +75,34 @@ BEGIN
      <<taxdetail>>
      FOR _taxd IN
 	SELECT taxdetail_tax_code, taxdetail_tax_id,taxdetail_taxrate_percent,COALESCE(taxdetail_taxrate_amount,0.00) as taxdetail_taxrate_amount,
-	       taxdetail_taxclass_sequence as seq 
+	       taxdetail_taxclass_sequence as seq
 	FROM calculatetaxdetail(ptaxzone, _taxt.taxass_taxtype_id, pdate, pcurr, pamount)
 	ORDER BY taxdetail_taxclass_sequence DESC
-	
+
      LOOP
      -- Calculate Tax Amount
        _taxamount = ((_subtotal * _taxd.taxdetail_taxrate_percent) + _taxd.taxdetail_taxrate_amount) * _sense;
-       
+
        -- Insert Tax Line
        EXECUTE format(_sql, _table, pDate, _taxd.taxdetail_tax_id, _taxamount, _taxt.taxass_taxtype_id, pMemoid, pCurr,
                       COALESCE(pCurrRate, currrate(pCurr,pDate)), pDate);
 
        -- Check for and post reverse VAT charges
-       IF (EXISTS(SELECT 1 FROM taxass 
-                  WHERE ((taxass_reverse_tax) 
+       IF (EXISTS(SELECT 1 FROM taxass
+                  WHERE ((taxass_reverse_tax)
                   AND (COALESCE(taxass_taxzone_id, -1) = ptaxzone)
-                  AND (COALESCE(taxass_taxtype_id, -1) IN (getAdjustmentTaxTypeId(), -1))))) THEN      
+                  AND (COALESCE(taxass_taxtype_id, -1) IN (getAdjustmentTaxTypeId(), -1))))) THEN
           EXECUTE format(_revsql, _table, pDate, _taxd.taxdetail_tax_id, _taxamount, _taxt.taxass_taxtype_id, pMemoid);
        END IF;
-       
+
        _total = _total + _taxamount;
        -- _subtotal = _subtotal - _taxamount;
-       
+
      END LOOP taxdetail;
    END LOOP taxtypes;
 
-    -- All done   
+    -- All done
     RETURN ABS(_total);
-    
+
 END;
 $func$ LANGUAGE plpgsql;

--- a/foundation-database/public/functions/updatememotax.sql
+++ b/foundation-database/public/functions/updatememotax.sql
@@ -1,3 +1,4 @@
+DROP FUNCTION IF EXISTS updatememotax(text, text, integer, integer, date, integer, numeric);
 DROP FUNCTION IF EXISTS updatememotax(text, text, integer, integer, date, integer, numeric, numeric);
 
 CREATE OR REPLACE FUNCTION updatememotax(


### PR DESCRIPTION
Still requires Tax assignment to be correctly configured otherwise GL to tax history discrepancies can occur, but makes assignment a bit more robust in the case of voided vouchers