### PR TITLE
Fixes #31688 Improve Shipment tracking by Sales Order Number query performance

### DIFF
--- a/database/source/xt/views/shipheadinfo.sql
+++ b/database/source/xt/views/shipheadinfo.sql
@@ -38,6 +38,7 @@ select xt.create_view('xt.shipheadinfo', $$
   from (
     select
       shiphead.*,
+      cohead_number AS ordhead_number,
       cohead.obj_uuid as order_uuid
     from shiphead
       join cohead on shiphead_order_id = cohead_id


### PR DESCRIPTION
Reduce query time from 97 seconds to 142ms.
For:
https://github.com/xtuple/xdruple-extension/pull/57
https://github.com/xtuple/xdruple-extension/pull/58
