### PR TITLE
[33452] - Default sequence name is table_column, not table_table.

### DIFF
--- a/lib/orm/source/xt/functions/add_column.sql
+++ b/lib/orm/source/xt/functions/add_column.sql
@@ -119,7 +119,7 @@ BEGIN
   END IF;
 
   IF (pType ~~* 'serial') THEN
-    _sequence := format('%I_%I_id_seq', pTable, pTable);
+    _sequence := format('%I_%I_id_seq', pTable, pColumn);
     IF (EXISTS(SELECT 1 FROM pg_class WHERE relname=_sequence
                AND relkind='S' AND relacl IS NULL ORDER BY relname)) THEN
       _query := format('GRANT ALL ON SEQUENCE %I.%I TO xtrole;', pSchema, _sequence);


### PR DESCRIPTION
Root cause of https://github.com/xtuple/xdruple-extension/pull/129