### PR TITLE
[33596] - remove call to formatdate when it isn't needed

### DIFF
--- a/foundation-database/public/functions/formatdate.sql
+++ b/foundation-database/public/functions/formatdate.sql
@@ -1,42 +1,36 @@
 
-CREATE OR REPLACE FUNCTION formatDate(TIMESTAMP WITH TIME ZONE) RETURNS TEXT IMMUTABLE AS '
--- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple. 
+CREATE OR REPLACE FUNCTION formatDate(TIMESTAMP WITH TIME ZONE) RETURNS TEXT IMMUTABLE AS $$
+-- Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
-SELECT TO_CHAR($1, COALESCE((SELECT locale_dateformat
-                             FROM locale, usr
-                             WHERE ((usr_locale_id=locale_id)
-                              AND (usr_username=getEffectiveXtUser())) ),
-                            ''yyyy-mm-dd'' )) AS result
-' LANGUAGE 'sql';
+  SELECT TO_CHAR($1, COALESCE((SELECT locale_dateformat
+                                 FROM locale
+                                 JOIN usrpref ON locale_id = usrpref_value::integer
+                                             AND usrpref_name = 'locale_id'
+                                WHERE usrpref_username = getEffectiveXtUser()),
+                              'yyyy-mm-dd')) AS result
+$$ LANGUAGE sql;
 
-
-CREATE OR REPLACE FUNCTION formatDate(DATE) RETURNS TEXT IMMUTABLE AS '
--- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple. 
+CREATE OR REPLACE FUNCTION formatDate(DATE) RETURNS TEXT IMMUTABLE AS $$
+-- Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
-SELECT TO_CHAR($1, COALESCE((SELECT locale_dateformat
-                             FROM locale, usr
-                             WHERE ((usr_locale_id=locale_id)
-                              AND (usr_username=getEffectiveXtUser())) ),
-                            ''yyyy-mm-dd'') ) AS result
-' LANGUAGE 'sql';
+  SELECT TO_CHAR($1, COALESCE((SELECT locale_dateformat
+                                 FROM locale
+                                 JOIN usrpref ON locale_id = usrpref_value::integer
+                                             AND usrpref_name = 'locale_id'
+                               WHERE usrpref_username = getEffectiveXtUser()),
+                              'yyyy-mm-dd')) AS result
+$$ LANGUAGE sql;
 
-CREATE OR REPLACE FUNCTION formatDate(DATE, TEXT) RETURNS TEXT IMMUTABLE AS '
--- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple. 
+--DROP FUNCTION IF EXISTS formatDate(DATE, TEXT);
+CREATE OR REPLACE FUNCTION formatDate(pDate DATE, pString TEXT) RETURNS TEXT IMMUTABLE AS $$
+-- Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
-DECLARE
-  pDate ALIAS FOR $1;
-  pString ALIAS FOR $2;
-
 BEGIN
-
-  IF ( (pDate = startOfTime()) OR
-       (pDate = endOfTime()) OR
-       (pDate IS NULL) ) THEN
+  IF pDate = startOfTime() OR pDate = endOfTime() OR pDate IS NULL THEN
     RETURN pString;
   ELSE
     RETURN formatDate(pDate);
   END IF;
-
 END;
-' LANGUAGE 'plpgsql';
+$$ LANGUAGE plpgsql;
 

--- a/foundation-database/public/tables/metasql/workOrderSchedule-detail.mql
+++ b/foundation-database/public/tables/metasql/workOrderSchedule-detail.mql
@@ -1,7 +1,7 @@
 -- Group: workOrderSchedule
 -- Name:  detail
 -- Notes: 
--- Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+-- Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
 
 SELECT wo_id,
@@ -14,10 +14,12 @@ SELECT wo_id,
        CASE wo_ordtype WHEN ('S') THEN formatSoitemNumber(wo_ordid)
                        WHEN ('W') THEN formatWoNumber(wo_ordid)
        END AS parentorder,
+<? if exists("isReport") ?>
        formatQty(wo_qtyord) AS ordered,
        formatQty(wo_qtyrcv) AS received,
        formatDate(wo_startdate) AS startdate,
        formatDate(wo_duedate) AS duedate,
+<? endif ?>
        formatWONumber(wo_id) AS wonumber,
        'qty' AS wo_qtyord_xtnumericrole,
        'qty' AS wo_qtyrcv_xtnumericrole,
@@ -69,7 +71,8 @@ WHERE ( (true)
 <? endif ?>
 <? if exists("woSoStatus") ?>
   AND (coitem_status <> 'X')
-<? elseif exists("woSoStatusMismatch") ?>
+<? endif ?>
+<? if exists("woSoStatusMismatch") ?>
   AND (coitem_status='C')
 <? endif ?>
 <? if exists("prj_id") ?>
@@ -93,16 +96,9 @@ WHERE ( (true)
                      WHERE (wo_id=<? value("wo_id") ?>)))
 <? endif ?>
 <? if exists("status_list") ?>
-<? foreach("status_list") ?>
-  <? if isfirst("status_list") ?>
-    AND (wo_status=<? value("status_list") ?>
-  <? else ?>
-    OR wo_status=<? value("status_list") ?>
-  <? endif ?>
-  <? if islast("status_list") ?>
-    )
-  <? endif ?>
-<? endforeach ?>
+  AND wo_status IN ('nOnExIsTeNt'
+    <? foreach("status_list") ?> , <? value("status_list") ?> <? endforeach ?>
+  )
 <? elseif exists("showOnlyRI") ?>
   AND (wo_status IN ('R','I'))
 <? else ?>
@@ -149,11 +145,7 @@ WHERE ( (true)
 <? endif ?>
    )
 ORDER BY 
-<? if exists("sortByStartDate") ?>
-  wo_startdate,
-<? elseif exists("sortByDueDate") ?>
-  wo_duedate,
-<? elseif exists("sortByItemNumber") ?>
-  item_number,
-<? endif ?>
+<? if exists("sortByStartDate") ?>  wo_startdate, <? endif ?>
+<? if exists("sortByDueDate") ?>    wo_duedate,   <? endif ?>
+<? if exists("sortByItemNumber") ?> item_number,  <? endif ?>
   wo_number, wo_subnumber;

--- a/test/database/functions/formatdate.js
+++ b/test/database/functions/formatdate.js
@@ -1,0 +1,68 @@
+var _      = require("underscore"),
+    assert = require("chai").assert,
+    dblib  = require("../dblib");
+
+(function () {
+  "use strict";
+
+  describe("formatDate()", function () {
+
+    var datasource = dblib.datasource,
+        adminCred  = dblib.generateCreds()
+        ;
+
+    it("should accept a date", function (done) {
+      var sql = "select formatDate(current_date) AS result;";
+      datasource.query(sql, adminCred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        assert.closeTo(new Date(res.rows[0].result), new Date(), 1000 * 60 * 60 * 24);
+        done();
+      });
+    });
+
+    it("should accept a timestamp with time zone", function (done) {
+      var sql = "select formatDate(current_timestamp) AS result;";
+      datasource.query(sql, adminCred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        assert.closeTo(new Date(res.rows[0].result), new Date(), 1000 * 60 * 60 * 24);
+        done();
+      });
+    });
+
+    it("should return its second arg if given a null date", function (done) {
+      var sql = "select formatDate(NULL, 'nulldate') AS result;";
+      datasource.query(sql, adminCred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        assert.equal(res.rows[0].result, 'nulldate');
+        done();
+      });
+    });
+
+    it("should return its second arg if given start of time", function (done) {
+      var sql = "select formatDate(startOfTime(), 'sot') AS result;";
+      datasource.query(sql, adminCred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        assert.equal(res.rows[0].result, 'sot');
+        done();
+      });
+    });
+
+    it("should return its second arg if given end of time", function (done) {
+      var sql = "select formatDate(endOfTime(), 'eot') AS result;";
+      datasource.query(sql, adminCred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        assert.equal(res.rows[0].result, 'eot');
+        done();
+      });
+    });
+
+
+  });
+
+})();
+

--- a/test/database/metasql/workOrderSchedule-detail.js
+++ b/test/database/metasql/workOrderSchedule-detail.js
@@ -1,0 +1,81 @@
+var _      = require("underscore"),
+    assert = require('chai').assert,
+    dblib  = require('../dblib');
+
+(function () {
+  "use strict";
+  var group  = "workOrderSchedule",
+      name   = "detail"
+      ;
+
+  describe(group + '-' + name + ' mql', function () {
+    var datasource = dblib.datasource,
+        adminCred  = dblib.generateCreds(),
+        constants  = { open:      'Open', exploded: 'Exploded', released: 'Released',
+                       inprocess: 'WIP',  closed:   'Closed',
+                       wo:        'Work Order',  planord: 'Planned Order', mps: 'MPS',
+                       so:        'Sales Order', quote:   'Quote',
+                       overdue:   'Late', ontime: 'On Time'
+                     },
+          mql
+          ;
+
+    before(function (done) {
+      var sql = "select metasql_query from metasql" +
+                " where metasql_group = $1"         +
+                "   and metasql_name  = $2"         +
+                "   and metasql_grade = 0;",
+          cred = _.extend({}, adminCred, { parameters: [ group, name ] });
+
+      datasource.query(sql, cred, function (err, res) {
+        assert.isNull(err);
+        assert.equal(res.rowCount, 1);
+        mql = res.rows[0].metasql_query;
+        mql = mql.replace(/"/g, "'").replace(/--.*\n/g, "").replace(/\n/g, " ");
+        done();
+      });
+    });
+
+    _.each([ constants,
+             _.extend({}, constants, { isReport:           true }),
+             _.extend({}, constants, { woSoStatus:         true }),
+             _.extend({}, constants, { woSoStatusMismatch: true }),
+             _.extend({}, constants, { showOnlyRI:         true }),
+             _.extend({}, constants, { showOnlyTopLevel:   true }),
+             _.extend({}, constants, { sortByStartDate:    true }),
+             _.extend({}, constants, { sortByDueDate:      true }),
+             _.extend({}, constants, { sortByItemNumber:   true }),
+             _.extend({}, constants, { classcode_id:      1 }),
+             _.extend({}, constants, { classcode_pattern: 'A' }),
+             _.extend({}, constants, { endDate:           '2018-12-31' }),
+             _.extend({}, constants, { item_id:           2 }),
+             _.extend({}, constants, { itemgrp_id:        3 }),
+             _.extend({}, constants, { itemgrp_pattern:   'B' }),
+             _.extend({}, constants, { plancode_id:       4 }),
+             _.extend({}, constants, { plancode_pattern:  'C' }),
+             _.extend({}, constants, { prj_id:            5 }),
+             _.extend({}, constants, { search_pattern:    'D' }),
+             _.extend({}, constants, { startDate:         '2018-01-01' }),
+//           _.extend({}, constants, { status_list:       [ 'E', 'O' ] }),
+             _.extend({}, constants, { warehous_id:       6 }),
+             _.extend({}, constants, { wo_id:             7 }),
+//           _.extend({}, constants, { wrkcnt_id:         8 }),
+//           _.extend({}, constants, { wrkcnt_pattern:    'F' }),
+
+    ], function (p) {
+        it(JSON.stringify(p), function (done) {
+           var sql = "do $$"
+              + "var params = { params: " + JSON.stringify(p) + "},"
+              + "    mql    = \""         + mql               + "\","
+              + "    sql    = XT.MetaSQL.parser.parse(mql, params),"
+              + "    rows   = plv8.execute(sql);"
+              + "$$ language plv8;";
+          datasource.query(sql, adminCred, function (err /*, res*/) {
+            assert.isNull(err);
+            done();
+          });
+        });
+    });
+  });
+
+}());


### PR DESCRIPTION
and improve performance when it is.

The changes to the `formatdate()` functions change the runtime of the following query significantly:

```SQL
select formatdate(gltrans_date) from gltrans limit 1000;
```

With 17K users the runtime went from 19200 ms to 560 ms in one test database.