### PR TITLE
[33551] Migrate Item Group documents and characteristics from xtcore …

### DIFF
--- a/foundation-database/public/patches/populate_source.sql
+++ b/foundation-database/public/patches/populate_source.sql
@@ -894,3 +894,19 @@ SELECT createDocType(NULL,
                      'gltrans_docnumber',
                      'firstline(gltrans_notes)'
 );
+
+SELECT createDoctype(NULL,
+                     'ITEMGRP',
+                     'ITEMGRP',
+                     'ITEMGRP',
+                     'Item Group',
+                     'itemgrp',
+                     'itemgrp_id',
+                     'itemgrp_name',
+                     'itemgrp_descrip',
+                     'itemgrp_catalog::text',
+                     'SELECT itemgrp_id, itemgrp_name, itemgrp_name FROM itemgrp ORDER BY 2;',
+                     '',
+                     'itemgrp_id',
+                     'itemGroup',
+                     '');


### PR DESCRIPTION
…to core

No data migration is necessary for existing commercial companies.

related to xtuple/private-extensions#1017