### PR TITLE
[25224] misc performance tweaks

### DIFF
--- a/foundation-database/public/functions/_docinfo.sql
+++ b/foundation-database/public/functions/_docinfo.sql
@@ -69,16 +69,16 @@ BEGIN
                     AND docass_target_type = pRefType
 
   LOOP
-    RETURN QUERY SELECT _target.docass_id,
-                         target_doc_number,
-                         _target.docass_target_type,
-                         _target.docass_target_id,
-                         pRefType,
-                         pRefId,
-                         target_doc_name,
-                         target_doc_descrip,
-                         _target.docass_purpose,
-                         _target.docass_notes
+    RETURN QUERY SELECT _target.docass_id::INTEGER,
+                         target_doc_number::TEXT,
+                         _target.docass_target_type::TEXT,
+                         _target.docass_target_id::INTEGER,
+                         pRefType::TEXT,
+                         pRefId::INTEGER,
+                         target_doc_name::TEXT,
+                         target_doc_descrip::TEXT,
+                         _target.docass_purpose::TEXT,
+                         _target.docass_notes::TEXT
                     FROM _getTargetDocument(_target.docass_id, _target.source_id, pRefId);
   END LOOP;
 

--- a/foundation-database/public/functions/buildsearchpath.sql
+++ b/foundation-database/public/functions/buildsearchpath.sql
@@ -40,7 +40,7 @@ BEGIN
   RETURN _path;
 END;
 $$
-LANGUAGE 'plpgsql';
+LANGUAGE plpgsql STABLE;
 
 COMMENT ON FUNCTION buildSearchPath() IS
 'buildSearchPath() examines the schemaord and pkghead tables to build a search

--- a/foundation-database/public/functions/packageisenabled.sql
+++ b/foundation-database/public/functions/packageisenabled.sql
@@ -1,36 +1,21 @@
 CREATE OR REPLACE FUNCTION packageIsEnabled(pId INTEGER) RETURNS BOOLEAN AS $$
--- Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple. 
+-- Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple. 
 -- See www.xtuple.com/CPAL for the full text of the software license.
-DECLARE
-  _pkgname TEXT;
-
-BEGIN
-
-  SELECT pkghead_name INTO _pkgname
+  SELECT packageIsEnabled(pkghead_name)
     FROM pkghead
-   WHERE pkghead_id=pId;
-
-  RETURN packageIsEnabled(_pkgname);
-
-END;
-$$ LANGUAGE plpgsql;
+   WHERE pkghead_id = pId;
+$$ LANGUAGE sql STABLE;
 
 CREATE OR REPLACE FUNCTION packageIsEnabled(pName TEXT) RETURNS BOOLEAN AS $$
--- Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple. 
+-- Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple. 
 -- See www.xtuple.com/CPAL for the full text of the software license.
-DECLARE
-  _result BOOLEAN;
-
-BEGIN
-
-  SELECT BOOL_OR(parent.relname IN ('cmd',  'cmdarg', 'image',  'metasql', 'priv', 'report', 'script', 'uiform', 'dict')) INTO _result
-    FROM pg_inherits
-    JOIN pg_class parent ON inhparent=parent.oid
-    JOIN pg_class child ON inhrelid=child.oid
-    JOIN pg_namespace ON child.relnamespace=pg_namespace.oid
-   WHERE nspname=pName;
-
-   RETURN COALESCE(_result, FALSE);
-
-END;
-$$ LANGUAGE plpgsql;
+  SELECT EXISTS(SELECT 1
+                 FROM pg_inherits
+                 JOIN pg_class child ON inhrelid = child.oid
+                 JOIN pg_namespace   ON child.relnamespace = pg_namespace.oid
+                WHERE nspname = pName
+                  AND child.relkind = 'r'
+                  AND relname IN ('pkgcmd',  'pkgcmdarg', 'pkgimage',  'pkgmetasql',
+                                  'pkgpriv', 'pkgreport', 'pkgscript', 'pkguiform',
+                                  'pkgdict'));
+$$ LANGUAGE sql STABLE;

--- a/foundation-database/public/functions/packageisenabled.sql
+++ b/foundation-database/public/functions/packageisenabled.sql
@@ -1,13 +1,5 @@
-CREATE OR REPLACE FUNCTION packageIsEnabled(pId INTEGER) RETURNS BOOLEAN AS $$
--- Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple. 
--- See www.xtuple.com/CPAL for the full text of the software license.
-  SELECT packageIsEnabled(pkghead_name)
-    FROM pkghead
-   WHERE pkghead_id = pId;
-$$ LANGUAGE sql STABLE;
-
 CREATE OR REPLACE FUNCTION packageIsEnabled(pName TEXT) RETURNS BOOLEAN AS $$
--- Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple. 
+-- Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
   SELECT EXISTS(SELECT 1
                  FROM pg_inherits
@@ -18,4 +10,12 @@ CREATE OR REPLACE FUNCTION packageIsEnabled(pName TEXT) RETURNS BOOLEAN AS $$
                   AND relname IN ('pkgcmd',  'pkgcmdarg', 'pkgimage',  'pkgmetasql',
                                   'pkgpriv', 'pkgreport', 'pkgscript', 'pkguiform',
                                   'pkgdict'));
+$$ LANGUAGE sql STABLE;
+
+CREATE OR REPLACE FUNCTION packageIsEnabled(pId INTEGER) RETURNS BOOLEAN AS $$
+-- Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
+-- See www.xtuple.com/CPAL for the full text of the software license.
+  SELECT packageIsEnabled(pkghead_name)
+    FROM pkghead
+   WHERE pkghead_id = pId;
 $$ LANGUAGE sql STABLE;

--- a/foundation-database/public/tables/custinfo.sql
+++ b/foundation-database/public/tables/custinfo.sql
@@ -66,7 +66,6 @@ SELECT
                     $$CHECK (cust_creditstatus IN ('G', 'W', 'H'))$$, 'public'),
   xt.add_constraint('custinfo', 'custinfo_cust_number_check',
                     $$CHECK (cust_number <> ''::text)$$, 'public'),
-  xt.add_constraint('custinfo', 'custinfo_cust_number_key', 'UNIQUE (cust_number)', 'public'),
   xt.add_constraint('custinfo', 'custinfo_cust_terms_fkey',
                     'FOREIGN KEY (cust_terms_id) REFERENCES terms(terms_id)
                      ON UPDATE RESTRICT ON DELETE RESTRICT', 'public'),
@@ -89,6 +88,11 @@ SELECT
   xt.add_constraint('custinfo', 'custinfo_cust_salesrep_fkey',
                     'FOREIGN KEY (cust_salesrep_id) REFERENCES salesrep(salesrep_id)
                      ON UPDATE RESTRICT ON DELETE RESTRICT', 'public');
+
+-- replace the old constraining index with one better suited to the custcluster completer
+-- but xt.add_index() can't handle UNIQUE yet
+ALTER TABLE public.custinfo drop constraint IF EXISTS custinfo_cust_number_key;
+CREATE UNIQUE INDEX IF NOT EXISTS custinfo_cust_number_key ON public.custinfo (cust_number text_pattern_ops);
 
 ALTER TABLE public.custinfo ENABLE TRIGGER ALL;
 


### PR DESCRIPTION
- Simplifying queries often makes them faster
- Indexing `cust_number text_pattern_ops` lets the customer cluster completer use an index instead of running table scans