### PR TITLE
[33899] Fully define column data type to timestamp with time zone

### DIFF
--- a/database/source/xt/tables/oa2client.sql
+++ b/database/source/xt/tables/oa2client.sql
@@ -1,61 +1,27 @@
--- table definition
+DROP VIEW IF EXISTS xdruple.oauth_2_token;
+DROP VIEW IF EXISTS xdruple.oauth_2_client;
 
-select xt.create_table('oa2client');
-select xt.add_column('oa2client','oa2client_id', 'serial', 'primary key', 'xt', 'oa2client table primary key.');
-select xt.add_column('oa2client','oa2client_client_id', 'text', 'not null unique', 'xt', 'Generated client_id obtained during application registration.');
-select xt.add_column('oa2client','oa2client_client_secret', 'text', 'unique', 'xt', 'The client secret obtained during application registration.');
-select xt.add_column('oa2client','oa2client_client_name', 'text', '', 'xt', 'Name of the client or application.');
-select xt.add_column('oa2client','oa2client_client_email', 'text', '', 'xt', 'Email address of the client.');
-select xt.add_column('oa2client','oa2client_client_web_site', 'text', '', 'xt', 'Web site of the client.');
-select xt.add_column('oa2client','oa2client_client_logo', 'text', '', 'xt', 'URL to client logo image file displayed during auth grant.');
-select xt.add_column('oa2client','oa2client_client_type', 'text', '', 'xt', 'The OAuth 2.0 client type: "web_server", "installed_app", "service_account"');
-select xt.add_column('oa2client','oa2client_active', 'boolean', '', 'xt', 'Flag to make a client active or not.');
-select xt.add_column('oa2client','oa2client_issued', 'timestamp', '', 'xt', 'The datetime that the client was registered');
-select xt.add_column('oa2client','oa2client_auth_uri', 'text', '', 'xt', 'The Authorization Endpoint URI.');
-select xt.add_column('oa2client','oa2client_token_uri', 'text', '', 'xt', 'The Token Endpoint URI.');
-select xt.add_column('oa2client','oa2client_delegated_access', 'boolean', '', 'xt', 'Flag to allow "service_account" client to use delegated access as another user.');
-select xt.add_column('oa2client','oa2client_client_x509_pub_cert', 'text', '', 'xt', 'The public x509 certificate, used to verify JWTs signed by the client.');
-select xt.add_column('oa2client','oa2client_org', 'text', 'not null default current_database()', 'xt', 'The name of the current database.');
-
-comment on table xt.oa2client is 'Defines global OAuth 2.0 server registered client storage.';
-
-----------------------------------------------------------
--- Upsert row defining Client using oauth single signon
-----------------------------------------------------------
-DELETE FROM xt.oa2client WHERE oa2client_client_id = 'oauthsso';
-
-INSERT INTO xt.oa2client
-(oa2client_client_id,
-oa2client_client_secret,
-oa2client_client_name,
-oa2client_client_email,
-oa2client_client_web_site,
-oa2client_client_logo,
-oa2client_client_type,
-oa2client_active,
-oa2client_issued,
-oa2client_auth_uri,
-oa2client_token_uri,
-oa2client_delegated_access,
-oa2client_client_x509_pub_cert)
 SELECT
-'oauthsso',
-'oauthsso',
-'xTuple',
-'info@xtuple.com',
-'www.xtuple.com',
-NULL,
-'assertion',
-true,
-'2013-06-20 01:00:00.000000',
-'dialog/authorize',
-'oauth/token',
-true,
-'-----BEGIN PUBLIC KEY-----
-MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQChqPrMA4/kRvvZr2iyNfvZl/yG
-QsPjuDHFtFNxydfMk1ZHDofLUd83mJeu4I18RBTAwrQHk8askA3DhlL6jOkGs81V
-ia8RqkAgoDslgQrcckD4mduxRUDQ/n2LGK50VsgfXA4VsPD7eU2G32W9GrhV6R/i
-Y+HkgBjVqN7Nxy/2sQIDAQAB
------END PUBLIC KEY-----
-'
-WHERE NOT EXISTS (SELECT 1 from xt.oa2client WHERE oa2client_client_id = 'oauthsso');
+  xt.create_table('oa2client');
+
+SELECT
+  xt.add_column('oa2client','oa2client_id', 'serial', 'primary key', 'xt', 'oa2client table primary key.'),
+  xt.add_column('oa2client','oa2client_client_id', 'text', 'not null unique', 'xt', 'Generated client_id obtained during application registration.'),
+  xt.add_column('oa2client','oa2client_client_secret', 'text', 'unique', 'xt', 'The client secret obtained during application registration.'),
+  xt.add_column('oa2client','oa2client_client_name', 'text', '', 'xt', 'Name of the client or application.'),
+  xt.add_column('oa2client','oa2client_client_email', 'text', '', 'xt', 'Email address of the client.'),
+  xt.add_column('oa2client','oa2client_client_web_site', 'text', '', 'xt', 'Web site of the client.'),
+  xt.add_column('oa2client','oa2client_client_logo', 'text', '', 'xt', 'URL to client logo image file displayed during auth grant.'),
+  xt.add_column('oa2client','oa2client_client_type', 'text', '', 'xt', 'The OAuth 2.0 client type: "web_server", "installed_app", "service_account"'),
+  xt.add_column('oa2client','oa2client_active', 'boolean', '', 'xt', 'Flag to make a client active or not.'),
+  xt.add_column('oa2client','oa2client_issued', 'timestamp with time zone', '', 'xt', 'The datetime that the client was registered'),
+  xt.add_column('oa2client','oa2client_auth_uri', 'text', '', 'xt', 'The Authorization Endpoint URI.'),
+  xt.add_column('oa2client','oa2client_token_uri', 'text', '', 'xt', 'The Token Endpoint URI.'),
+  xt.add_column('oa2client','oa2client_delegated_access', 'boolean', '', 'xt', 'Flag to allow "service_account" client to use delegated access as another user.'),
+  xt.add_column('oa2client','oa2client_client_x509_pub_cert', 'text', '', 'xt', 'The public x509 certificate, used to verify JWTs signed by the client.'),
+  xt.add_column('oa2client','oa2client_org', 'text', 'not null default current_database()', 'xt', 'The name of the current database.');
+
+COMMENT ON TABLE xt.oa2client IS 'Defines global OAuth 2.0 server registered client storage.';
+
+-- Remove old, unused OAuth 2.0 single signon token.
+DELETE FROM xt.oa2client WHERE oa2client_client_id = 'oauthsso';

--- a/database/source/xt/tables/oa2token.sql
+++ b/database/source/xt/tables/oa2token.sql
@@ -1,24 +1,29 @@
--- table definition
+DROP VIEW IF EXISTS xdruple.oauth_2_token;
+DROP VIEW IF EXISTS xm.oauth2token;
+DROP VIEW IF EXISTS sys.oauth2token;
 
-select xt.create_table('oa2token');
-select xt.add_column('oa2token','oa2token_id', 'serial', 'primary key', 'xt', 'oa2token table primary key.');
-select xt.add_column('oa2token','oa2token_username', 'text', '', 'xt', 'Indicates the username this token exchange is for.');
-select xt.add_column('oa2token','oa2token_client_id', 'text', 'not null references xt.oa2client (oa2client_client_id) on delete cascade', 'xt', 'Indicates the client that is making the request.');
-select xt.add_column('oa2token','oa2token_redirect_uri', 'text', '', 'xt', 'Determines where the response is sent.');
-select xt.add_column('oa2token','oa2token_scope', 'text', 'not null', 'xt', 'Indicates the xTuple org access your application is requesting.');
-select xt.add_column('oa2token','oa2token_state', 'text', '', 'xt', 'Indicates any state which may be useful to your application upon receipt of the response.');
-select xt.add_column('oa2token','oa2token_approval_prompt', 'boolean', '', 'xt', 'Indicates if the user should be re-prompted for consent.');
-select xt.add_column('oa2token','oa2token_auth_code', 'text', 'unique', 'xt', 'The auth code returned from the initial authorization request.');
-select xt.add_column('oa2token','oa2token_auth_code_issued', 'timestamp', '', 'xt', 'The datetime the auth code was issued.');
-select xt.add_column('oa2token','oa2token_auth_code_expires', 'timestamp', '', 'xt', 'The datetime that the auth code expires.');
-select xt.add_column('oa2token','oa2token_refresh_token', 'text', 'unique', 'xt', 'The refresh token used to get a new access token when an old one expires.');
-select xt.add_column('oa2token','oa2token_refresh_issued', 'timestamp', '', 'xt', 'The datetime the refresh token was issued.');
-select xt.add_column('oa2token','oa2token_refresh_expires', 'timestamp', '', 'xt', 'The datetime that the refresh token expires.');
-select xt.add_column('oa2token','oa2token_access_token', 'text', 'unique', 'xt', 'The current access token to be included with every API call.');
-select xt.add_column('oa2token','oa2token_access_issued', 'timestamp', '', 'xt', 'The datetime the access token was issued.');
-select xt.add_column('oa2token','oa2token_access_expires', 'timestamp', '', 'xt', 'The datetime that the access token expires.');
-select xt.add_column('oa2token','oa2token_token_type', 'text', 'not null', 'xt', 'Indicates the type of token returned. At this time, this field will always have the value Bearer.');
-select xt.add_column('oa2token','oa2token_access_type', 'text', '', 'xt', 'Indicates if a web_server needs to access an API when the user is not present.');
-select xt.add_column('oa2token','oa2token_delegate', 'text', '', 'xt', 'username for which a service_account is requesting delegated access as.');
+SELECT
+  xt.create_table('oa2token');
 
-comment on table xt.oa2token is 'Defines global OAuth 2.0 server token storage.';
+SELECT
+  xt.add_column('oa2token','oa2token_id', 'serial', 'primary key', 'xt', 'oa2token table primary key.'),
+  xt.add_column('oa2token','oa2token_username', 'text', '', 'xt', 'Indicates the username this token exchange is for.'),
+  xt.add_column('oa2token','oa2token_client_id', 'text', 'not null references xt.oa2client (oa2client_client_id) on delete cascade', 'xt', 'Indicates the client that is making the request.'),
+  xt.add_column('oa2token','oa2token_redirect_uri', 'text', '', 'xt', 'Determines where the response is sent.'),
+  xt.add_column('oa2token','oa2token_scope', 'text', 'not null', 'xt', 'Indicates the xTuple org access your application is requesting.'),
+  xt.add_column('oa2token','oa2token_state', 'text', '', 'xt', 'Indicates any state which may be useful to your application upon receipt of the response.'),
+  xt.add_column('oa2token','oa2token_approval_prompt', 'boolean', '', 'xt', 'Indicates if the user should be re-prompted for consent.'),
+  xt.add_column('oa2token','oa2token_auth_code', 'text', 'unique', 'xt', 'The auth code returned from the initial authorization request.'),
+  xt.add_column('oa2token','oa2token_auth_code_issued', 'timestamp with time zone', '', 'xt', 'The datetime the auth code was issued.'),
+  xt.add_column('oa2token','oa2token_auth_code_expires', 'timestamp with time zone', '', 'xt', 'The datetime that the auth code expires.'),
+  xt.add_column('oa2token','oa2token_refresh_token', 'text', 'unique', 'xt', 'The refresh token used to get a new access token when an old one expires.'),
+  xt.add_column('oa2token','oa2token_refresh_issued', 'timestamp with time zone', '', 'xt', 'The datetime the refresh token was issued.'),
+  xt.add_column('oa2token','oa2token_refresh_expires', 'timestamp with time zone', '', 'xt', 'The datetime that the refresh token expires.'),
+  xt.add_column('oa2token','oa2token_access_token', 'text', 'unique', 'xt', 'The current access token to be included with every API call.'),
+  xt.add_column('oa2token','oa2token_access_issued', 'timestamp with time zone', '', 'xt', 'The datetime the access token was issued.'),
+  xt.add_column('oa2token','oa2token_access_expires', 'timestamp with time zone', '', 'xt', 'The datetime that the access token expires.'),
+  xt.add_column('oa2token','oa2token_token_type', 'text', 'not null', 'xt', 'Indicates the type of token returned. At this time, this field will always have the value Bearer.'),
+  xt.add_column('oa2token','oa2token_access_type', 'text', '', 'xt', 'Indicates if a web_server needs to access an API when the user is not present.'),
+  xt.add_column('oa2token','oa2token_delegate', 'text', '', 'xt', 'username for which a service_account is requesting delegated access as.');
+
+COMMENT ON TABLE xt.oa2token IS 'Defines global OAuth 2.0 server token storage.';

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "jsdoc-specs": "rm -rf scripts/output/*;mkdir scripts/output/tech-specs;./node_modules/xtuple-documentation/node_modules/jsdoc/jsdoc -t ./node_modules/xtuple-documentation/jsdoc-setup/spec-templates -c ./node_modules/xtuple-documentation/jsdoc-setup/jsdoc.conf.json -d ./scripts/output/tech-specs/ -r ./test/specs ./node_modules/xtuple-documentation/jsdoc-setup/tech-specs-readme.md;mkdir scripts/output/user-specs;./node_modules/xtuple-documentation/node_modules/jsdoc/jsdoc -t ./node_modules/xtuple-documentation/jsdoc-setup/spec-templates -c ./node_modules/xtuple-documentation/jsdoc-setup/jsdoc-user.conf.json -d ./scripts/output/user-specs/ -r ./test/specs ./node_modules/xtuple-documentation/jsdoc-setup/user-specs-readme.md;",
     "start": "node_modules/.bin/nodemon node-datasource/main.js --debug --watch node-datasource",
     "test-build": "./node_modules/.bin/mocha -R spec test/build/build_app.js",
+    "test-rebuild": "./node_modules/.bin/mocha -R spec test/build/rebuild.js",
     "test": "./node_modules/.bin/mocha -R spec test/database/*"
   }
 }

--- a/test/build/rebuild.js
+++ b/test/build/rebuild.js
@@ -1,0 +1,27 @@
+var buildAll = require('../../scripts/lib/build_all'),
+  assert = require('chai').assert,
+  datasource = require('../../node-datasource/lib/ext/datasource').dataSource,
+  path = require('path');
+
+(function () {
+  "use strict";
+  describe('The database build tool', function () {
+    this.timeout(100 * 60 * 1000);
+
+    var loginData = require(path.join(__dirname, "../lib/login_data.js")).data,
+      datasource = require('../../../xtuple/node-datasource/lib/ext/datasource').dataSource,
+      config = require(path.join(__dirname, "../../node-datasource/config.js")),
+      creds = config.databaseServer,
+      databaseName = loginData.org;
+
+    it('should rebuild without error on a already built database', function (done) {
+      buildAll.build({
+        database: databaseName,
+        wipeViews: true
+      }, function (err, res) {
+        assert.isNull(err);
+        done();
+      });
+    });
+  });
+}());


### PR DESCRIPTION
After adding the `xdruple.oauth_2_token` and `xdruple.oauth_2_client` views, when `add_column()` runs on the `xt.oa2token` and `xt.oa2client` table, we get this error:

```sql
ERROR:  cannot alter type of a column used by a view or rule
DETAIL:  rule _RETURN on view oauth_2_client depends on column "oa2client_issued"
CONTEXT:  SQL statement "ALTER TABLE xt.oa2token ALTER COLUMN oa2token_auth_code_expires SET DATA TYPE timestamp"
```

This appears to be happening because `timestamp` is converted to `timestamp without time zone` and `add_column()`'s check for column type differences sees this as a change.

This PR fully defines the column types as `timestamp with time zone` and drops the dependent views before running `add_column()`. Those views will then be added back later in the build process. On the next build, `add_column()` will not detect a type change for these columns.
