### PR TITLE
[34009] Turn KeyGen script into a console application with a DB connection

### DIFF
--- a/scripts/keygen.js
+++ b/scripts/keygen.js
@@ -52,10 +52,7 @@
       for (let parameter in parameters) {
         if (parameters.hasOwnProperty(parameter)) {
           query = query.replace(
-            new RegExp(
-              '{{ parameter }}'.replace('parameter', parameter),
-              'g'
-            ),
+            new RegExp(`{{ ${parameter} }}`, 'g'),
             parameters[parameter]
           );
         }
@@ -65,7 +62,6 @@
   }
 
   let erp = new DataSource();
-
   Promise.resolve()
     .then(() => {
       return new Promise((resolve, reject) => {

--- a/scripts/keygen.js
+++ b/scripts/keygen.js
@@ -27,7 +27,7 @@
   /**
    * @constructor
    */
-  let DataSource = function () {
+  function DataSource() {
     this.dataSource = require('../node-datasource/lib/ext/datasource').dataSource;
     this.credentials = require(script.config).databaseServer;
     this.credentials.database = script.database;
@@ -46,14 +46,14 @@
         );
       });
     };
-  };
+  }
 
   /**
    * @constructor
    * @param {(string|string[])} query
    * @param {Array.<string>}    parameters
    */
-  let Query = function (query, parameters) {
+  function Query(query, parameters) {
     /**
      * @returns {string}
      */
@@ -69,7 +69,7 @@
     this.parameters = function () {
       return parameters;
     };
-  };
+  }
 
   /** @type {{psi: Object, asn1: Object, pkcs12: Object}} */
   let forge = require('node-forge');

--- a/scripts/keygen.js
+++ b/scripts/keygen.js
@@ -63,33 +63,26 @@
         );
       }
     );
-    fs.readFile(
-      '{directory}/sql/application.sql'.replace('{directory}', __dirname),
-      'utf8',
-      function (error, content) {
-        /** @var string content */
+    dataSource.query(
+      "DELETE FROM xdruple.xd_site WHERE xd_site_name = '{name}'"
+        .replace('{name}', script.application),
+      credentials,
+      function (error) {
         if (error) {
           throw error;
         }
         dataSource.query(
-          "DELETE FROM xdruple.xd_site WHERE xd_site_name = '{name}'"
-            .replace('{name}', script.application),
+          [
+            "INSERT INTO xdruple.xd_site (xd_site_name, xd_site_url)",
+            "VALUES ('{name}', '{url}');"
+          ].join(' ')
+           .replace('{name}', script.application)
+           .replace('{url}', script.application),
           credentials,
           function (error) {
             if (error) {
               throw error;
             }
-            dataSource.query(
-              content
-                .replace('{name}', script.application)
-                .replace('{url}', script.application),
-              credentials,
-              function (error) {
-                if (error) {
-                  throw error;
-                }
-              }
-            );
           }
         );
       }

--- a/scripts/keygen.js
+++ b/scripts/keygen.js
@@ -80,14 +80,6 @@
     .then((keypair) => {
       Promise.resolve()
         .then(() => {
-          return erp.execute(new Query(
-            "DELETE FROM xt.oa2client WHERE oa2client_client_id = '{{ id }}'",
-            {
-              id: script.database
-            }
-          ));
-        })
-        .then(() => {
           return new Promise((resolve, reject) => {
             fs.readFile(
               '{directory}/sql/oauth2client.sql'.replace('{directory}', __dirname),
@@ -133,17 +125,11 @@
 
   Promise.resolve()
     .then(() => {
-      return erp.execute(new Query(
-        "DELETE FROM xdruple.xd_site WHERE xd_site_name = '{{ name }}'",
-        {
-          name: script.application
-        }
-      ));
-    })
-    .then(() => {
       return erp.execute(new Query([
         "INSERT INTO xdruple.xd_site (xd_site_name, xd_site_url)",
-        "VALUES ('{{ name }}', '{{ url }}');"
+        "VALUES ('{{ name }}', '{{ url }}')",
+        "ON CONFLICT (xd_site_name) DO UPDATE",
+        "SET xd_site_name = '{{ name }}', xd_site_url='{{ url }}'"
       ], {
         name: script.application,
         url: script.application

--- a/scripts/keygen.js
+++ b/scripts/keygen.js
@@ -1,26 +1,98 @@
+#!/usr/bin/env node
+/*jshint node:true */
 (function () {
   'use strict';
   var forge = require('node-forge');
   var fs = require('fs');
+
+  var script = require('commander')
+    .option('-c, --config </path/to/file>', 'Location of the config file.')
+    .option('-d, --database <name>', 'Database name')
+    .option('-i, --iss <issuer>', 'Issuer ID (ISS)')
+    .option('-p, --path </path/to/p12/output>', 'Path to p12 file output')
+    .option('-a, --application <name>', 'Application (xDruple site name)')
+    .parse(process.argv);
+  var credentials = require(script.config).databaseServer;
+  credentials.database = script.database;
+
   forge.pki.rsa.generateKeyPair(2048, 65537, null, function (error, keypair) {
     if (error) {
-      console.log(error);
       throw error;
     }
-    fs.writeFile('public.pem', forge.pki.publicKeyToPem(keypair.publicKey), function (error) {
-      if (error) {
-        console.log(error);
+    var dataSource = require('../node-datasource/lib/ext/datasource').dataSource;
+    fs.readFile(
+      '{directory}/sql/oauth2client.sql'.replace('{directory}', __dirname),
+      'utf8',
+      function (error, content) {
+        /** @var string content */
+        if (error) {
+          throw error;
+        }
+        dataSource.query(
+          "DELETE FROM xt.oa2client WHERE oa2client_client_id = '{id}'"
+            .replace('{id}', script.database),
+          credentials,
+          function (error) {
+            if (error) {
+              throw error;
+            }
+            dataSource.query(
+              content
+                .replace('{id}', script.iss)
+                .replace('{client}', script.iss)
+                .replace('{public_key}', forge.pki.publicKeyToPem(keypair.publicKey))
+                .replace('{organization}', script.database),
+              credentials,
+              function (error) {
+                if (error) {
+                  throw error;
+                }
+                fs.writeFile(script.path, new Buffer(new Buffer(
+                  forge.asn1.toDer(
+                    forge.pkcs12.toPkcs12Asn1(keypair.privateKey, null, 'notasecret')
+                  ).getBytes(),
+                  'binary'
+                ), 'base64'), function (error) {
+                  if (error) {
+                    throw error;
+                  }
+                });
+              }
+            );
+          }
+        );
       }
-    });
-    fs.writeFile('private.p12', new Buffer(new Buffer(
-      forge.asn1.toDer(
-        forge.pkcs12.toPkcs12Asn1(keypair.privateKey, null, 'notasecret')
-      ).getBytes(),
-      'binary'
-    ), 'base64'), function (error) {
-      if (error) {
-        console.log(error);
+    );
+    fs.readFile(
+      '{directory}/sql/application.sql'.replace('{directory}', __dirname),
+      'utf8',
+      function (error, content) {
+        /** @var string content */
+        if (error) {
+          throw error;
+        }
+        dataSource.query(
+          "DELETE FROM xdruple.xd_site WHERE xd_site_name = '{name}'"
+            .replace('{name}', script.application),
+          credentials,
+          function (error) {
+            if (error) {
+              throw error;
+            }
+            dataSource.query(
+              content
+                .replace('{name}', script.application)
+                .replace('{url}', script.application),
+              credentials,
+              function (error) {
+                if (error) {
+                  throw error;
+                }
+              }
+            );
+          }
+        );
       }
-    });
+    );
   });
 }());

--- a/scripts/keygen.js
+++ b/scripts/keygen.js
@@ -65,49 +65,59 @@
   /** @type {{psi: Object, asn1: Object, pkcs12: Object}} */
   let forge = require('node-forge');
   let filesystem = require('fs');
-  let Promises = {
-    createKeypair: function (resolve, reject) {
-      forge.pki.rsa.generateKeyPair(2048, 65537, null, (error, keypair) => {
-        if (error) {
-          reject(error);
-        }
-        resolve(keypair);
-      });
-    },
-    readOAuth2ClientSQLFile: function (resolve, reject) {
-      filesystem.readFile(
-        '{directory}/sql/oauth2client.sql'.replace('{directory}', __dirname),
-        'utf8',
-        (error, content) => {
+  let promises = {
+    /**
+     * @returns {Promise}
+     */
+    generateRSAKeyPair: function (bits, exponent) {
+      return new Promise((resolve, reject) => {
+        forge.pki.rsa.generateKeyPair(bits, exponent, null, (error, keypair) => {
           if (error) {
             reject(error);
           }
-          resolve(content);
-        }
-      );
+          resolve(keypair);
+        });
+      });
     },
-    saveP12File: function (privateKey) {
-      return (resolve, reject) => {
-        filesystem.writeFile(script.path, new Buffer(new Buffer(
-          forge.asn1.toDer(
-            forge.pkcs12.toPkcs12Asn1(privateKey, null, 'notasecret')
-          ).getBytes(),
-          'binary'
-        ), 'base64'), (error, result) => {
+    /**
+     * @param {string} path
+     * @returns {Promise}
+     */
+    readFile: function (path) {
+      return new Promise((resolve, reject) => {
+        filesystem.readFile(path, 'utf8', (error, content) => {
+            if (error) {
+              reject(error);
+            }
+            resolve(content);
+          }
+        );
+      });
+    },
+    /**
+     * @param {string} path
+     * @param {Buffer} data
+     * @returns {Promise}
+     */
+    writeFile: function (path, data) {
+      return new Promise((resolve, reject) => {
+        filesystem.writeFile(path, data, (error, result) => {
           if (error) {
             reject(error);
           }
           resolve(result);
         });
-      };
+      });
     }
   };
 
   let erp = new DataSource();
   Promise
     .all([
-      new Promise(Promises.createKeypair),
-      new Promise(Promises.readOAuth2ClientSQLFile)
+      promises.generateRSAKeyPair(2048, 65537),
+      promises.readFile(
+        '{{ directory }}/sql/oauth2client.sql'.replace('{{ directory }}', __dirname)
+      )
     ])
     .then((results) => {
       let keypair = results[0];
@@ -118,15 +128,26 @@
           script.iss,
           forge.pki.publicKeyToPem(keypair.publicKey)
         ])),
-        new Promise(Promises.saveP12File(keypair.privateKey))
+        promises.writeFile(
+          script.path,
+          new Buffer(
+            new Buffer(
+              forge.asn1.toDer(
+                forge.pkcs12.toPkcs12Asn1(keypair.privateKey, null, 'notasecret')
+              ).getBytes(),
+              'binary'
+            ),
+            'base64'
+          )
+        )
       ]);
     })
     .then(() => {
       return erp.execute(new Query([
-        "INSERT INTO xdruple.xd_site (xd_site_name, xd_site_url)",
-        "VALUES ($1, $2)",
-        "ON CONFLICT (xd_site_name) DO UPDATE",
-        "SET xd_site_name = $1, xd_site_url = $2"
+        'INSERT INTO xdruple.xd_site (xd_site_name, xd_site_url)',
+        'VALUES ($1, $2)',
+        'ON CONFLICT (xd_site_name) DO UPDATE',
+        'SET xd_site_name = $1, xd_site_url = $2'
       ], [
         script.application,
         script.application

--- a/scripts/keygen.js
+++ b/scripts/keygen.js
@@ -15,7 +15,7 @@
    * @param {Function} reject
    * @returns {Function}
    */
-  let resolver = function (resolve, reject) {
+  let decide = function (resolve, reject) {
     return (error, result) => {
       if (error) {
         reject(error);
@@ -42,7 +42,7 @@
           Object.assign(this.credentials, {
             parameters: query.parameters()
           }),
-          resolver(resolve, reject)
+          decide(resolve, reject)
         );
       });
     };
@@ -80,7 +80,7 @@
      */
     generateRSAKeyPair: function (bits, exponent) {
       return new Promise((resolve, reject) => {
-        forge.pki.rsa.generateKeyPair(bits, exponent, null, resolver(resolve, reject));
+        forge.pki.rsa.generateKeyPair(bits, exponent, null, decide(resolve, reject));
       });
     },
     /**
@@ -89,7 +89,7 @@
      */
     readFile: function (path) {
       return new Promise((resolve, reject) => {
-        filesystem.readFile(path, 'utf8', resolver(resolve, reject));
+        filesystem.readFile(path, 'utf8', decide(resolve, reject));
       });
     },
     /**
@@ -99,7 +99,7 @@
      */
     writeFile: function (path, data) {
       return new Promise((resolve, reject) => {
-        filesystem.writeFile(path, data, resolver(resolve, reject));
+        filesystem.writeFile(path, data, decide(resolve, reject));
       });
     }
   };

--- a/scripts/keygen.js
+++ b/scripts/keygen.js
@@ -116,14 +116,9 @@
           });
         })
         .catch((error) => {
-          console.log(error);
+          throw error;
         });
     })
-    .catch((error) => {
-      console.log(error);
-    });
-
-  Promise.resolve()
     .then(() => {
       return erp.execute(new Query([
         "INSERT INTO xdruple.xd_site (xd_site_name, xd_site_url)",

--- a/scripts/keygen.js
+++ b/scripts/keygen.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
-/*jshint node:true */
+/* jshint node:true, esversion:6 */
 (function () {
   'use strict';
-  var forge = require('node-forge');
-  var fs = require('fs');
+  let forge = require('node-forge');
+  let fs = require('fs');
 
-  var script = require('commander')
+  let script = require('commander')
     .option('-c, --config </path/to/file>', 'Location of the config file.')
     .option('-d, --database <name>', 'Database name')
     .option('-i, --iss <issuer>', 'Issuer ID (ISS)')
@@ -25,7 +25,7 @@
      * @param {?Function} [success=null]
      */
     this.execute = function (query, success) {
-      this.dataSource.query(query.sql(), this.credentials, function (error) {
+      this.dataSource.query(query.sql(), this.credentials, (error) => {
         if (error) {
           throw error;
         }
@@ -49,7 +49,7 @@
       if (Array.isArray(query)) {
         query = query.join(' ');
       }
-      for (var parameter in parameters) {
+      for (let parameter in parameters) {
         if (parameters.hasOwnProperty(parameter)) {
           query = query.replace(
             '{{ parameter }}'.replace('parameter', parameter),
@@ -61,15 +61,15 @@
     };
   }
 
-  forge.pki.rsa.generateKeyPair(2048, 65537, null, function (error, keypair) {
+  forge.pki.rsa.generateKeyPair(2048, 65537, null, (error, keypair) => {
     if (error) {
       throw error;
     }
-    var erp = new DataSource();
+    let erp = new DataSource();
     fs.readFile(
       '{directory}/sql/oauth2client.sql'.replace('{directory}', __dirname),
       'utf8',
-      function (error, content) {
+      (error, content) => {
         /** @var string content */
         if (error) {
           throw error;
@@ -79,18 +79,18 @@
           {
             id: script.database
           }
-        ), function () {
+        ), () => {
           erp.execute(new Query(content, {
               id: script.iss,
               client: script.iss,
               key: forge.pki.publicKeyToPem(keypair.publicKey)
-            }), function () {
+            }), () => {
               fs.writeFile(script.path, new Buffer(new Buffer(
                 forge.asn1.toDer(
                   forge.pkcs12.toPkcs12Asn1(keypair.privateKey, null, 'notasecret')
                 ).getBytes(),
                 'binary'
-              ), 'base64'), function (error) {
+              ), 'base64'), (error) => {
                 if (error) {
                   throw error;
                 }
@@ -105,7 +105,7 @@
       {
         name: script.application
       }
-    ), function () {
+    ), () => {
       erp.execute(new Query([
         "INSERT INTO xdruple.xd_site (xd_site_name, xd_site_url)",
         "VALUES ('{{ name }}', '{{ url }}');"

--- a/scripts/keygen.js
+++ b/scripts/keygen.js
@@ -11,6 +11,20 @@
     .parse(process.argv);
 
   /**
+   * @param {Function} resolve
+   * @param {Function} reject
+   * @returns {Function}
+   */
+  let resolver = function (resolve, reject) {
+    return (error, result) => {
+      if (error) {
+        reject(error);
+      }
+      resolve(result);
+    };
+  };
+
+  /**
    * @constructor
    */
   let DataSource = function () {
@@ -28,12 +42,7 @@
           Object.assign(this.credentials, {
             parameters: query.parameters()
           }),
-          function (error, result) {
-            if (error) {
-              reject(error);
-            }
-            resolve(result);
-          }
+          resolver(resolve, reject)
         );
       });
     };
@@ -71,12 +80,7 @@
      */
     generateRSAKeyPair: function (bits, exponent) {
       return new Promise((resolve, reject) => {
-        forge.pki.rsa.generateKeyPair(bits, exponent, null, (error, keypair) => {
-          if (error) {
-            reject(error);
-          }
-          resolve(keypair);
-        });
+        forge.pki.rsa.generateKeyPair(bits, exponent, null, resolver(resolve, reject));
       });
     },
     /**
@@ -85,13 +89,7 @@
      */
     readFile: function (path) {
       return new Promise((resolve, reject) => {
-        filesystem.readFile(path, 'utf8', (error, content) => {
-            if (error) {
-              reject(error);
-            }
-            resolve(content);
-          }
-        );
+        filesystem.readFile(path, 'utf8', resolver(resolve, reject));
       });
     },
     /**
@@ -101,12 +99,7 @@
      */
     writeFile: function (path, data) {
       return new Promise((resolve, reject) => {
-        filesystem.writeFile(path, data, (error, result) => {
-          if (error) {
-            reject(error);
-          }
-          resolve(result);
-        });
+        filesystem.writeFile(path, data, resolver(resolve, reject));
       });
     }
   };

--- a/scripts/keygen.js
+++ b/scripts/keygen.js
@@ -52,7 +52,10 @@
       for (let parameter in parameters) {
         if (parameters.hasOwnProperty(parameter)) {
           query = query.replace(
-            '{{ parameter }}'.replace('parameter', parameter),
+            new RegExp(
+              '{{ parameter }}'.replace('parameter', parameter),
+              'g'
+            ),
             parameters[parameter]
           );
         }

--- a/scripts/sql/application.sql
+++ b/scripts/sql/application.sql
@@ -1,5 +1,0 @@
-INSERT INTO xdruple.xd_site (
-  xd_site_name,
-  xd_site_url
-)
-VALUES ('{name}', '{url}');

--- a/scripts/sql/application.sql
+++ b/scripts/sql/application.sql
@@ -1,0 +1,5 @@
+INSERT INTO xdruple.xd_site (
+  xd_site_name,
+  xd_site_url
+)
+VALUES ('{name}', '{url}');

--- a/scripts/sql/oauth2client.sql
+++ b/scripts/sql/oauth2client.sql
@@ -27,4 +27,8 @@ VALUES (
   null,
   true,
   '{{ key }}'
-);
+)
+ON CONFLICT (oa2client_client_id) DO UPDATE
+SET oa2client_issued = now(),
+    oa2client_client_name = '{{ client }}',
+    oa2client_client_x509_pub_cert = '{{ key }}'

--- a/scripts/sql/oauth2client.sql
+++ b/scripts/sql/oauth2client.sql
@@ -11,8 +11,7 @@ INSERT INTO xt.oa2client (
   oa2client_auth_uri,
   oa2client_token_uri,
   oa2client_delegated_access,
-  oa2client_client_x509_pub_cert,
-  oa2client_org
+  oa2client_client_x509_pub_cert
 )
 VALUES (
   '{{ id }}',
@@ -27,6 +26,5 @@ VALUES (
   null,
   null,
   true,
-  '{{ key }}',
-  '{{ organization }}'
+  '{{ key }}'
 );

--- a/scripts/sql/oauth2client.sql
+++ b/scripts/sql/oauth2client.sql
@@ -1,0 +1,32 @@
+INSERT INTO xt.oa2client (
+  oa2client_client_id,
+  oa2client_client_secret,
+  oa2client_client_name,
+  oa2client_client_email,
+  oa2client_client_web_site,
+  oa2client_client_logo,
+  oa2client_client_type,
+  oa2client_active,
+  oa2client_issued,
+  oa2client_auth_uri,
+  oa2client_token_uri,
+  oa2client_delegated_access,
+  oa2client_client_x509_pub_cert,
+  oa2client_org
+)
+VALUES (
+  '{id}',
+  xt.uuid_generate_v4(),
+  '{client}',
+  '',
+  '',
+  null,
+  'jwt bearer',
+  true,
+  now(),
+  null,
+  null,
+  true,
+  '{public_key}',
+  '{organization}'
+);

--- a/scripts/sql/oauth2client.sql
+++ b/scripts/sql/oauth2client.sql
@@ -15,9 +15,9 @@ INSERT INTO xt.oa2client (
   oa2client_org
 )
 VALUES (
-  '{id}',
+  '{{ id }}',
   xt.uuid_generate_v4(),
-  '{client}',
+  '{{ client }}',
   '',
   '',
   null,
@@ -27,6 +27,6 @@ VALUES (
   null,
   null,
   true,
-  '{public_key}',
-  '{organization}'
+  '{{ key }}',
+  '{{ organization }}'
 );

--- a/scripts/sql/oauth2client.sql
+++ b/scripts/sql/oauth2client.sql
@@ -14,9 +14,9 @@ INSERT INTO xt.oa2client (
   oa2client_client_x509_pub_cert
 )
 VALUES (
-  '{{ id }}',
+  $1,
   xt.uuid_generate_v4(),
-  '{{ client }}',
+  $2,
   '',
   '',
   null,
@@ -26,9 +26,9 @@ VALUES (
   null,
   null,
   true,
-  '{{ key }}'
+  $3
 )
 ON CONFLICT (oa2client_client_id) DO UPDATE
 SET oa2client_issued = now(),
-    oa2client_client_name = '{{ client }}',
-    oa2client_client_x509_pub_cert = '{{ key }}'
+    oa2client_client_name = $2,
+    oa2client_client_x509_pub_cert = $3


### PR DESCRIPTION
Script can be run same way as `build_app.js`:

```
DATABASE=pilot
CONFIG_DIR=/etc/xtuple/${DATABASE}
APPLICATION=pilot.example.com
ISSUER=pilot
KEY=pilot
./scripts/keygen.js \
        -c ${CONFIG_DIR}/config.js \
        -d ${DATABASE} \
        -a ${APPLICATION} \
        -i ${ISSUER} \
        -p /var/xtuple/keys/${KEY}.p12
```

This can be used to replace https://github.com/xtuple/xtuple-admin-utility/blob/master/functions/oatoken.fun and related calls.