### PR TITLE
build 4_12_x with a version of xtte without the crm changes for 5_0_x

### DIFF
--- a/scripts/release_build.sh
+++ b/scripts/release_build.sh
@@ -27,7 +27,7 @@ declare -a CONFIG=(\
   "qt-client          skip    skip     skip  not-needed"                                  \
   "updater            default skip     skip  not-needed"                                  \
   "xtdesktop          skip    [demp]   skip  resources"                                   \
-  "xtte               skip    [demp]   true  extensions/time_expense/foundation-database" \
+  "xtte               2_4_x   [demp]   true  extensions/time_expense/foundation-database" \
   "nodejsshim         skip    [dem]    true  foundation-database"                         \
   "xtdash             skip    [dem]    true  foundation-database"                         \
 )


### PR DESCRIPTION
This should fix recent build failures on the 4_12_x db