### PR TITLE
Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "engines": {
     "node": "0.8.x"
   },
+  "license": "CPAL-1.0",
   "main": "node-datasource/main.js",
   "scripts": {
     "jshint": "./node_modules/.bin/jshint lib/backbone-x/source lib/enyo-x/source lib/tools/source enyo-client/application/source/ enyo-client/extensions node-datasource",


### PR DESCRIPTION
Stops warning “xtuple@4.12.0-alpha No license field.”