### PR TITLE
[34055] Resolve partial save trigger SQL errors on new Incident

### DIFF
--- a/foundation-database/public/trigger_functions/incdt.sql
+++ b/foundation-database/public/trigger_functions/incdt.sql
@@ -16,21 +16,6 @@ BEGIN
     PERFORM clearNumberIssue('IncidentNumber', NEW.incdt_number);
   END IF;
 
-  -- Description is required
-  IF (LENGTH(COALESCE(NEW.incdt_summary,''))=0) THEN
-    RAISE EXCEPTION 'You must supply a valid Incident Description.';
-  END IF;
-
-  -- CRM Account is required
-  IF (NEW.incdt_crmacct_id IS NULL) THEN
-    RAISE EXCEPTION 'You must supply a valid CRM Account.';
-  END IF;
-
-  -- Contact is required
-  IF (NEW.incdt_cntct_id IS NULL) THEN
-    RAISE EXCEPTION 'You must supply a valid Contact.';
-  END IF;
-
   NEW.incdt_updated := now();
 
   -- Timestamps


### PR DESCRIPTION
Data integrity checks still exist in cpp code but had to be removed from the Trigger when partially saving an incident.