### PR TITLE
[34150] In ‘Copy Item’ screen, while copying the Item ‘Error Copying Item’ error dialog is displayed.

### DIFF
--- a/foundation-database/public/functions/createfile.sql
+++ b/foundation-database/public/functions/createfile.sql
@@ -3,8 +3,20 @@ drop function if exists createFile(TEXT, TEXT, BYTEA) cascade;
 create or replace function createFile(pTitle TEXT, pDescription TEXT, pStream BYTEA, pMimeType TEXT DEFAULT NULL) returns integer as $$
 declare
   _id integer;
+  pDefault text;
 begin
-  _id := nextval('file_file_id_seq');
+  select column_default 
+    into pDefault 
+      FROM INFORMATION_SCHEMA.COLUMNS 
+    where table_name = 'file' 
+      and column_name='file_id';
+
+  if pDefault like '%file_id%'
+    then _id := nextval('file_file_id_seq');
+  elsif(pDefault like '%url_id%') 
+    then _id := nextval('urlinfo_url_id_seq');
+  end if;   
+  
   insert into file (file_id, file_title, file_descrip, file_stream, file_mime_type) values (_id, pTitle, pDescription, pStream, COALESCE(pMimeType, 'application/octet-stream'));
   return _id;
 end;

--- a/foundation-database/public/functions/createfile.sql
+++ b/foundation-database/public/functions/createfile.sql
@@ -2,22 +2,8 @@ drop function if exists createFile(TEXT, TEXT, BYTEA) cascade;
 
 create or replace function createFile(pTitle TEXT, pDescription TEXT, pStream BYTEA, pMimeType TEXT DEFAULT NULL) returns integer as $$
 declare
-  _id integer;
-  pDefault text;
 begin
-  select column_default 
-    into pDefault 
-      FROM INFORMATION_SCHEMA.COLUMNS 
-    where table_name = 'file' 
-      and column_name='file_id';
-
-  if pDefault like '%file_id%'
-    then _id := nextval('file_file_id_seq');
-  elsif(pDefault like '%url_id%') 
-    then _id := nextval('urlinfo_url_id_seq');
-  end if;   
-  
-  insert into file (file_id, file_title, file_descrip, file_stream, file_mime_type) values (_id, pTitle, pDescription, pStream, COALESCE(pMimeType, 'application/octet-stream'));
-  return _id;
+  insert into file ( file_title, file_descrip, file_stream, file_mime_type) values ( pTitle, pDescription, pStream, COALESCE(pMimeType, 'application/octet-stream'));
+  return currval('file_file_id_seq');
 end;
 $$ language 'plpgsql';

--- a/foundation-database/public/functions/createurl.sql
+++ b/foundation-database/public/functions/createurl.sql
@@ -3,8 +3,20 @@ declare
   pTitle ALIAS FOR $1;
   pUrl ALIAS FOR $2;
   _id integer;
+  pDefault text;
 begin
-  _id := nextval('urlinfo_url_id_seq');
+  select column_default 
+    into pDefault 
+      FROM INFORMATION_SCHEMA.COLUMNS 
+    where table_name = 'urlinfo' 
+      and column_name='url_id';
+
+  if pDefault like '%file_id%'
+    then _id := nextval('file_file_id_seq');
+  elsif(pDefault like '%url_id%') 
+    then _id := nextval('urlinfo_url_id_seq');
+  end if;   
+  
   insert into urlinfo (url_id, url_title, url_url) values (_id, pTitle, pUrl);
   return _id;
 end;

--- a/foundation-database/public/functions/createurl.sql
+++ b/foundation-database/public/functions/createurl.sql
@@ -2,22 +2,8 @@ create or replace function createUrl(text, text) returns integer as $$
 declare
   pTitle ALIAS FOR $1;
   pUrl ALIAS FOR $2;
-  _id integer;
-  pDefault text;
 begin
-  select column_default 
-    into pDefault 
-      FROM INFORMATION_SCHEMA.COLUMNS 
-    where table_name = 'urlinfo' 
-      and column_name='url_id';
-
-  if pDefault like '%file_id%'
-    then _id := nextval('file_file_id_seq');
-  elsif(pDefault like '%url_id%') 
-    then _id := nextval('urlinfo_url_id_seq');
-  end if;   
-  
-  insert into urlinfo (url_id, url_title, url_url) values (_id, pTitle, pUrl);
-  return _id;
+  insert into urlinfo ( url_title, url_url) values ( pTitle, pUrl);
+  return currval('file_file_id_seq');
 end;
 $$ language 'plpgsql';

--- a/foundation-database/public/views/url.sql
+++ b/foundation-database/public/views/url.sql
@@ -59,7 +59,6 @@ create or replace rule "_INSERT_URL" as on insert to url
 
 create or replace rule "_INSERT_FILE" as on insert to url 
   where new.url_stream is not null do instead
-
   insert into docass (
     docass_id,
     docass_source_id,


### PR DESCRIPTION
The bug (as far as I can tell) is the result of the postbooks DB being initialized to a state that causes an error when rows are added to the `urlinfo` table.

This is because (after a fresh postbooks DB restore): 
- `urlinfo` starts off with 1 row, with `url_id = 4`
- the `url_id` is generated by the sequence `urlinfo_url_id_seq` which starts at 2 
Therefore, at some point as rows are added to `urlinfo` we will try to insert a row with `url_id=4` when there is already one in the table, causing the error message.
This is also the reason I was able to reproduce the error dialog, by attaching a WebSite to a incident's document.

I noticed during my testing that `url_id` and `file_id` were not following the same sequence, because the `createFile` and `createUrl` functions would call nextval() on their respective sequences. That is what this code addresses.