### PR TITLE
[32398] Freight doubling under specific circumstances

### DIFF
--- a/foundation-database/public/functions/calcshipfreight.sql
+++ b/foundation-database/public/functions/calcshipfreight.sql
@@ -72,7 +72,7 @@ BEGIN
                     COALESCE((SELECT SUM(shiphead_freight)
                               FROM shiphead
                               WHERE (shiphead_order_id = _shipment.shiphead_order_id)
-                                AND (shiphead_shipped='true')), 0) ) INTO _result;
+                                AND (shiphead_id <> pShipheadId)), 0) ) INTO _result;
       RETURN _result;
     END IF;
 


### PR DESCRIPTION
This change only affects the freight calculations when the setup has been configured to not automatically calculate freight. 
The bug is caused by the `shiphead_freight` for all shipments being equal to the total SO freight amount (`cohead_freight`).
Its not ideal, but it adds all the freight from the SO to the first shipment (`shiphead_freight`) and 0 to the rest of the shipments.
