### PR TITLE
Fix sql bug in PackingList getreport metaSQL

### DIFF
--- a/foundation-database/public/tables/metasql/packingList-getreport.mql
+++ b/foundation-database/public/tables/metasql/packingList-getreport.mql
@@ -8,7 +8,7 @@
 SELECT findCustomerForm(cohead_cust_id,
                        <? value('form') ?>) AS reportname
   FROM cohead 
- WHERE (cohead_id=<? value('sohead_id' ?>);
+ WHERE cohead_id = <? value('sohead_id') ?>;
 <? elseif exists('tohead_id') ?>
 SELECT findTOForm(<? value('tohead_id') ?>,
                   <? value('form') ?>) AS reportname;


### PR DESCRIPTION
Found this bug when working on something else.  Been around for at least 5 years so I think this entire section of code is probably not used otherwise this would have been a problem much earlier.

However it _does_ allow for customer specific Packing List forms which is desired functionality (see issue #28314) so we probably need to revisit this code and make it work.