### PR TITLE
Make calculatetax function more robust for when no freight is required

### DIFF
--- a/foundation-database/public/functions/calculatetax.sql
+++ b/foundation-database/public/functions/calculatetax.sql
@@ -147,7 +147,7 @@ BEGIN
   _numlines := COALESCE(array_length(pLines, 1), 0);
   _includemisc := pMiscTaxtypeId IS NOT NULL;
 
-  _taxtypes := pTaxTypes || pFreightTaxtypeId;
+  _taxtypes := pTaxTypes || COALESCE(pFreightTaxtypeId, getfreighttaxtypeid());
   IF _includemisc THEN
     _taxtypes := _taxtypes || pMiscTaxtypeId;
   END IF;

--- a/foundation-database/public/functions/calculatetax.sql
+++ b/foundation-database/public/functions/calculatetax.sql
@@ -147,7 +147,10 @@ BEGIN
   _numlines := COALESCE(array_length(pLines, 1), 0);
   _includemisc := pMiscTaxtypeId IS NOT NULL;
 
-  _taxtypes := pTaxTypes || COALESCE(pFreightTaxtypeId, getfreighttaxtypeid());
+  _taxtypes := pTaxTypes;
+  IF (pFreightTaxtypeId IS NOT NULL) THEN
+    _taxtypes := _taxtypes || pFreightTaxtypeId;
+  END IF;
   IF _includemisc THEN
     _taxtypes := _taxtypes || pMiscTaxtypeId;
   END IF;


### PR DESCRIPTION
Function returned NULL if no freight taxtype id was supplied in params.  Found this when attempting to utilise via another function