### PR TITLE
[34261] Add Warehouse to Invoice header API view

### DIFF
--- a/test/database/views/invoiceline.js
+++ b/test/database/views/invoiceline.js
@@ -66,7 +66,7 @@ var _ = require("underscore"),
 
     it("should allow creating a new invoice", function (done) {
       var invoice  = "ROW('"+inv+"', NULL, NULL, NULL, NULL,"
-               +      "NULL, NULL, 0,"
+               +      "NULL, NULL, NULL, 0,"
                +      "NULL, NULL, 'TTOYS',"
                +      "NULL, NULL, NULL, NULL, NULL, "
                +      "NULL, NULL, NULL, NULL, NULL, "


### PR DESCRIPTION
Add `Site` field from `invchead` table, required for version 5.0 Tax calculation to work.

This change is required for revised Fixed Asset sales process which creates an Invoice and we need to trigger the tax calculation immediately.