### PR TITLE
 [18611] Resolve scenario that allows recursive BOM items

### DIFF
--- a/foundation-database/public/trigger_functions/bomitem.sql
+++ b/foundation-database/public/trigger_functions/bomitem.sql
@@ -22,17 +22,17 @@ BEGIN
    FROM item
    WHERE (item_id=NEW.bomitem_parent_item_id);
 
-    --  Make sure that the parent is not used in the component at some level
-    SELECT indentedWhereUsed(NEW.bomitem_parent_item_id) INTO _bomworksetid;
-    SELECT bomwork_id INTO _bomworkid
-    FROM bomwork
-    WHERE ((bomwork_set_id=_bomworksetid)
-      AND  (bomwork_item_id=NEW.bomitem_item_id))
-    LIMIT 1;
-    IF (FOUND) THEN
-      PERFORM deleteBOMWorkset(_bomworksetid);
-      RAISE EXCEPTION 'BOM Item Parent is used by Component, BOM is recursive. [xtuple: createBOMItem, -2]';
-    END IF;
+  --  Make sure that the parent is not used in the component at some level
+  SELECT indentedWhereUsed(NEW.bomitem_parent_item_id) INTO _bomworksetid;
+  SELECT bomwork_id INTO _bomworkid
+  FROM bomwork
+  WHERE ((bomwork_set_id=_bomworksetid)
+    AND  (bomwork_item_id=NEW.bomitem_item_id))
+  LIMIT 1;
+  IF (FOUND) THEN
+    PERFORM deleteBOMWorkset(_bomworksetid);
+    RAISE EXCEPTION 'BOM Item Parent is used by Component, BOM is recursive. [xtuple: createBOMItem, -2]';
+  END IF;
 
   IF (TG_OP = 'INSERT') THEN
     --  Make sure that the parent and component are not the same

--- a/foundation-database/public/trigger_functions/bomitem.sql
+++ b/foundation-database/public/trigger_functions/bomitem.sql
@@ -22,12 +22,6 @@ BEGIN
    FROM item
    WHERE (item_id=NEW.bomitem_parent_item_id);
 
-  IF (TG_OP = 'INSERT') THEN
-    --  Make sure that the parent and component are not the same
-    IF (NEW.bomitem_parent_item_id = NEW.bomitem_item_id) THEN
-      RAISE EXCEPTION 'BOM Item Parent and Component Item cannot be the same. [xtuple: createBOMItem, -1]';
-    END IF;
-
     --  Make sure that the parent is not used in the component at some level
     SELECT indentedWhereUsed(NEW.bomitem_parent_item_id) INTO _bomworksetid;
     SELECT bomwork_id INTO _bomworkid
@@ -38,6 +32,12 @@ BEGIN
     IF (FOUND) THEN
       PERFORM deleteBOMWorkset(_bomworksetid);
       RAISE EXCEPTION 'BOM Item Parent is used by Component, BOM is recursive. [xtuple: createBOMItem, -2]';
+    END IF;
+
+  IF (TG_OP = 'INSERT') THEN
+    --  Make sure that the parent and component are not the same
+    IF (NEW.bomitem_parent_item_id = NEW.bomitem_item_id) THEN
+      RAISE EXCEPTION 'BOM Item Parent and Component Item cannot be the same. [xtuple: createBOMItem, -1]';
     END IF;
 
     PERFORM deleteBOMWorkset(_bomworksetid);


### PR DESCRIPTION
Check was only being undertaken when inserting new items, not when un-expiring existing items.

There is a scenario that exists where you attempt to expire an item that is in a recursive BOM where the check goes off and never appears to return - you have to crash out of the application.  I have not resolved that issue, but it should never occur in the first place - especially after this fix.

Backport to 4.12