### PR TITLE
[34802] Fix qtyreserved() performance issue on large databases.

### DIFF
--- a/foundation-database/public/functions/qtyreserved.sql
+++ b/foundation-database/public/functions/qtyreserved.sql
@@ -1,15 +1,10 @@
 CREATE OR REPLACE FUNCTION qtyReserved(pItemsiteid INTEGER) RETURNS NUMERIC AS $$
--- Copyright (c) 1999-2019 by OpenMFG LLC, d/b/a xTuple. 
+-- Copyright (c) 1999-2019 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/EULA for the full text of the software license.
-DECLARE
-  _qty NUMERIC;
 
-BEGIN
-
-  SELECT COALESCE(SUM(coitem_qtyreserved),0) INTO _qty
+  SELECT COALESCE(SUM(coitem_qtyreserved),0)
     FROM coitem
-   WHERE(coitem_itemsite_id=pItemsiteid);
+   WHERE coitem_itemsite_id = pItemsiteid
+     AND coitem_status <> ALL ('{X,C}'::bpchar[]);
 
-  RETURN _qty;
-END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE sql STABLE;

--- a/foundation-database/public/indexes/coitem.sql
+++ b/foundation-database/public/indexes/coitem.sql
@@ -2,3 +2,19 @@ select xt.add_index('coitem', 'coitem_cohead_id', 'coitem_cohead_id_key', 'btree
 select xt.add_index('coitem', 'coitem_itemsite_id', 'coitem_itemsite_id', 'btree', 'public');
 select xt.add_index('coitem', 'coitem_linenumber', 'coitem_linenumber_key', 'btree', 'public');
 select xt.add_index('coitem', 'coitem_status', 'coitem_status_key', 'btree', 'public');
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+      SELECT 1
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE c.relname = 'coitem_status_open_idx'
+        AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX coitem_status_open_idx
+    ON coitem (coitem_id)
+    WHERE (coitem_status != ALL ('{X,C}'::bpchar[]));
+  END IF;
+END
+$$;


### PR DESCRIPTION
There is a performance bottleneck in the `qtyreserved(itemsite_id)` function:

```sql
  SELECT COALESCE(SUM(coitem_qtyreserved),0) INTO _qty
    FROM coitem
   WHERE(coitem_itemsite_id=pItemsiteid);
```

It is slow with 300,000 rows for a matching `coitem_itemsite_id`. The `coitem_qtyreserved` is set to `0` for any coitem records that have a status of `X` (canceled) or `C` (closed) in the `_soitemTrigger()` trigger. Those records can be skipped with a `WHERE` clause and sped up with an index.

```sql
  SELECT COALESCE(SUM(coitem_qtyreserved),0)
    FROM coitem
   WHERE coitem_itemsite_id = pItemsiteid
     AND coitem_status <> ALL ('{X,C}'::bpchar[]);
```

After this change, the original query runs in 75.652 ms from a cold cache vs 72 seconds.
