### PR TITLE
[34761] Revert closing of job costed W/O to shipping transaction.  

### DIFF
--- a/foundation-database/public/functions/postsoitemproduction.sql
+++ b/foundation-database/public/functions/postsoitemproduction.sql
@@ -59,7 +59,11 @@ BEGIN
      AND (wo_ordtype='S')
      AND (coitem_id=pSoItemid));
     
--- move the closing of the W/O to createInvoice
+   UPDATE wo SET wo_status = 'C'
+    WHERE wo_ordid=pSoItemid
+      AND wo_ordtype='S'
+      AND wo_qtyrcv >= wo_qtyord;
+
   END IF;
 
   RETURN _itemlocSeries;


### PR DESCRIPTION
Resolve COGS bug where a job costed item was not generating COGS entries due to not finding an appropriate item cost from the W/O.

This fix does _not_ address historic data which will be corrupted.

requires associated cpp client change

Also fixes issue #34800