### PR TITLE
[34979] Modify the Project Contact detail source in Projects List

### DIFF
--- a/foundation-database/public/tables/metasql/projects-detail_nohierarchy.mql
+++ b/foundation-database/public/tables/metasql/projects-detail_nohierarchy.mql
@@ -60,9 +60,7 @@ SELECT prj_id AS id, 1 AS altId,
   FROM prj()
   LEFT JOIN prjtype ON (prj_prjtype_id=prjtype_id)
   LEFT JOIN crmacct ON (prj_crmacct_id=crmacct_id)
-  LEFT OUTER JOIN crmacctcntctass ON (crmacct_id=crmacctcntctass_crmacct_id
-                                  AND crmacctcntctass_crmrole_id = getcrmroleid('Primary'))
-  LEFT OUTER JOIN cntct ON (crmacctcntctass_cntct_id=cntct_id)
+  LEFT OUTER JOIN cntct ON (prj_cntct_id=cntct_id)
   LEFT JOIN addr ON (cntct_addr_id=addr_id)
 <? foreach("char_id_text_list") ?>
   LEFT OUTER JOIN chartext charass_alias<? literal("char_id_text_list") ?> ON ((charass_alias<? literal("char_id_text_list") ?>.charass_target_id=prj_id)


### PR DESCRIPTION
Was originally pointing to CRM Account contact so is not technically a bug, but was confusing for the user.  Checked 4.12 and it (recently) points to the project contact so this change makes it consistent between 4.12 and 5.0