### PR TITLE
[34848] Cleanup createpr(). Check for existing PR before creating it.

### DIFF
--- a/foundation-database/public/functions/createpr.sql
+++ b/foundation-database/public/functions/createpr.sql
@@ -6,7 +6,8 @@ CREATE OR REPLACE FUNCTION createPr(
   pDueDate DATE,
   pNotes TEXT,
   pOrderType CHARACTER(1),
-  pOrderId INTEGER
+  pOrderId INTEGER,
+  pProjId INTEGER DEFAULT NULL::INTEGER
 ) RETURNS INTEGER AS $$
 -- Copyright (c) 1999-2019 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
@@ -29,11 +30,11 @@ BEGIN
   SELECT NEXTVAL('pr_pr_id_seq') INTO _prid;
   INSERT INTO pr
   ( pr_id, pr_number, pr_subnumber, pr_status,
-    pr_order_type, pr_order_id,
+    pr_order_type, pr_order_id, pr_prj_id,
     pr_itemsite_id, pr_qtyreq, pr_duedate, pr_releasenote )
   VALUES
   ( _prid, pOrderNumber, nextPrSubnumber(pOrderNumber), 'O',
-    pOrderType, pOrderId,
+    pOrderType, pOrderId, pProjId
     pItemsiteid, pQty, pDuedate, pNotes );
 
   RETURN _prid;
@@ -179,7 +180,8 @@ BEGIN
     _parent.duedate,
     COALESCE(pParentNotes, _parent.notes),
     pParentType,
-    pParentId
+    pParentId,
+    _parent.prjid
   );
 
   RETURN _prid;

--- a/foundation-database/public/functions/createpr.sql
+++ b/foundation-database/public/functions/createpr.sql
@@ -1,17 +1,30 @@
-CREATE OR REPLACE FUNCTION createPr(INTEGER, INTEGER, NUMERIC, DATE, TEXT, CHARACTER(1), INTEGER) RETURNS INTEGER AS $$
--- Copyright (c) 1999-2019 by OpenMFG LLC, d/b/a xTuple. 
+DROP FUNCTION IF EXISTS createPr(INTEGER, INTEGER, NUMERIC, DATE, TEXT, CHARACTER(1), INTEGER);
+CREATE OR REPLACE FUNCTION createPr(
+  pOrderNumber INTEGER,
+  pItemsiteid INTEGER,
+  pQty NUMERIC,
+  pDueDate DATE,
+  pNotes TEXT,
+  pOrderType CHARACTER(1),
+  pOrderId INTEGER
+) RETURNS INTEGER AS $$
+-- Copyright (c) 1999-2019 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
 DECLARE
-  pOrderNumber ALIAS FOR $1;
-  pItemsiteid ALIAS FOR $2;
-  pQty ALIAS FOR $3;
-  pDueDate ALIAS FOR $4;
-  pNotes ALIAS FOR $5;
-  pOrderType ALIAS FOR $6;
-  pOrderId ALIAS FOR $7;
   _prid INTEGER;
 
 BEGIN
+
+  -- Check for existing pr for this pOrderId and pOrderType.
+  SELECT pr_id INTO _prid
+    FROM pr
+   WHERE pr_order_id = pOrderId
+     AND pr_order_type = pOrderType
+     AND pOrderId != -1
+     AND pOrderType != 'M';
+  IF _prid IS NOT NULL THEN
+    RETURN _prid;
+  END IF;
 
   SELECT NEXTVAL('pr_pr_id_seq') INTO _prid;
   INSERT INTO pr
@@ -28,16 +41,17 @@ BEGIN
 END;
 $$ LANGUAGE 'plpgsql';
 
-
-CREATE OR REPLACE FUNCTION createPr(INTEGER, INTEGER, NUMERIC, DATE, TEXT) RETURNS INTEGER AS $$
--- Copyright (c) 1999-2019 by OpenMFG LLC, d/b/a xTuple. 
+DROP FUNCTION IF EXISTS createPr(INTEGER, INTEGER, NUMERIC, DATE, TEXT);
+CREATE OR REPLACE FUNCTION createPr(
+  pOrderNumber INTEGER,
+  pItemsiteid INTEGER,
+  pQty NUMERIC,
+  pDueDate DATE,
+  pNotes TEXT
+) RETURNS INTEGER AS $$
+-- Copyright (c) 1999-2019 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
 DECLARE
-  pOrderNumber ALIAS FOR $1;
-  pItemsiteid ALIAS FOR $2;
-  pQty ALIAS FOR $3;
-  pDueDate ALIAS FOR $4;
-  pNotes ALIAS FOR $5;
   _prid INTEGER;
 
 BEGIN
@@ -57,14 +71,60 @@ BEGIN
 END;
 $$ LANGUAGE 'plpgsql';
 
-
-CREATE OR REPLACE FUNCTION createPr(INTEGER, CHAR, INTEGER) RETURNS INTEGER AS $$
--- Copyright (c) 1999-2019 by OpenMFG LLC, d/b/a xTuple. 
+DROP FUNCTION IF EXISTS createpr(CHAR, INTEGER);
+CREATE OR REPLACE FUNCTION createPr(
+  pParentType CHAR,
+  pParentId INTEGER
+) RETURNS INTEGER AS $$
+-- Copyright (c) 1999-2019 by OpenMFG LLC, d/b/a xTuple.
 -- See www.xtuple.com/CPAL for the full text of the software license.
 DECLARE
-  pOrderNumber ALIAS FOR $1;
-  pParentType ALIAS FOR $2;
-  pParentId ALIAS FOR $3;
+  _orderNumber INTEGER;
+  _prid INTEGER;
+
+BEGIN
+
+  IF pParentType = 'W' THEN
+    SELECT wo_number INTO _orderNumber
+      FROM wo, womatl
+     WHERE womatl_wo_id = wo_id
+       AND womatl_id = pParentId;
+
+  ELSIF pParentType = 'S' THEN
+    SELECT CAST(cohead_number AS INTEGER) INTO _orderNumber
+      FROM cohead, coitem
+     WHERE coitem_cohead_id = cohead_id
+       AND coitem_id = pParentId;
+
+  ELSIF pParentType = 'F' THEN
+    SELECT fetchPrNumber() INTO _orderNumber;
+
+  ELSE
+    RETURN -2;
+  END IF;
+
+  IF _orderNumber IS NULL THEN
+    RETURN -1;
+  END IF;
+
+  SELECT createPr(_orderNumber, pParentType, pParentId) INTO _prid;
+
+  RETURN _prid;
+
+END;
+$$ LANGUAGE 'plpgsql';
+
+DROP FUNCTION IF EXISTS createpr(INTEGER, CHARACTER, INTEGER);
+DROP FUNCTION IF EXISTS createpr(INTEGER, CHARACTER, INTEGER, TEXT);
+CREATE OR REPLACE FUNCTION createpr(
+  pOrderNumber INTEGER,
+  pParentType CHARACTER,
+  pParentId INTEGER,
+  pParentNotes TEXT DEFAULT NULL
+) RETURNS INTEGER AS $$
+-- Copyright (c) 1999-2019 by OpenMFG LLC, d/b/a xTuple.
+-- See www.xtuple.com/CPAL for the full text of the software license.
+DECLARE
   _parent RECORD;
   _prid INTEGER;
   _orderNumber INTEGER;
@@ -82,158 +142,45 @@ BEGIN
            itemuomtouom(itemsite_item_id, womatl_uom_id, NULL, womatl_qtyreq) AS qty,
            womatl_duedate AS duedate, wo_prj_id AS prjid,
            womatl_notes AS notes INTO _parent
-    FROM wo, womatl, itemsite
-    WHERE ((womatl_wo_id=wo_id)
-     AND (womatl_itemsite_id=itemsite_id)
-     AND (womatl_id=pParentId));
+      FROM wo, womatl, itemsite
+     WHERE womatl_wo_id = wo_id
+       AND womatl_itemsite_id = itemsite_id
+       AND womatl_id= pParentId;
 
   ELSIF (pParentType = 'S') THEN
     SELECT coitem_itemsite_id AS itemsiteid,
            (coitem_qtyord - coitem_qtyshipped + coitem_qtyreturned) AS qty,
            coitem_scheddate AS duedate, cohead_prj_id AS prjid,
            coitem_memo AS notes INTO _parent
-    FROM coitem, cohead
-    WHERE ((cohead_id=coitem_cohead_id)
-     AND (coitem_id=pParentId));
+      FROM coitem, cohead
+     WHERE cohead_id = coitem_cohead_id
+       AND coitem_id = pParentId;
 
   ELSIF (pParentType = 'F') THEN
     SELECT planord_itemsite_id AS itemsiteid,
            planord_qty AS qty,
            planord_duedate AS duedate, NULL::INTEGER AS prjid,
            planord_comments AS notes INTO _parent
-    FROM planord
-    WHERE (planord_id=pParentId);
+      FROM planord
+     WHERE planord_id = pParentId;
 
   ELSE
     RETURN -2;
   END IF;
 
-  IF (NOT FOUND) THEN
+  IF _parent IS NULL THEN
     RETURN -1;
   END IF;
 
-  SELECT NEXTVAL('pr_pr_id_seq') INTO _prid;
-  INSERT INTO pr
-  ( pr_id, pr_number, pr_subnumber, pr_status,
-    pr_order_type, pr_order_id, pr_prj_id,
-    pr_itemsite_id, pr_qtyreq,
-    pr_duedate, pr_releasenote )
-  VALUES
-  ( _prid, _orderNumber, nextPrSubnumber(_orderNumber), 'O',
-    pParentType, pParentId, _parent.prjid,
-    _parent.itemsiteid, validateOrderQty(_parent.itemsiteid, _parent.qty, TRUE),
-    _parent.duedate, _parent.notes );
-
-  RETURN _prid;
-
-END;
-$$ LANGUAGE 'plpgsql';
-
-
-CREATE OR REPLACE FUNCTION createPr(CHAR, INTEGER) RETURNS INTEGER AS $$
--- Copyright (c) 1999-2019 by OpenMFG LLC, d/b/a xTuple. 
--- See www.xtuple.com/CPAL for the full text of the software license.
-DECLARE
-  pParentType ALIAS FOR $1;
-  pParentId ALIAS FOR $2;
-  _orderNumber INTEGER;
-  _prid INTEGER;
-
-BEGIN
-
-  IF (pParentType = 'W') THEN
-    SELECT wo_number INTO _orderNumber
-    FROM wo, womatl
-    WHERE ((womatl_wo_id=wo_id)
-     AND (womatl_id=pParentId));
-
-  ELSIF (pParentType = 'S') THEN
-    SELECT CAST(cohead_number AS INTEGER) INTO _orderNumber
-    FROM cohead, coitem
-    WHERE ((coitem_cohead_id=cohead_id)
-     AND (coitem_id=pParentId));
-
-  ELSIF (pParentType = 'F') THEN
-    SELECT fetchPrNumber() INTO _orderNumber;
-
-  ELSE
-    RETURN -2;
-  END IF;
-
-  IF (NOT FOUND) THEN
-    RETURN -1;
-  END IF;
-
-  SELECT createPr(_orderNumber, pParentType, pParentId) INTO _prid;
-
-  RETURN _prid;
-
-END;
-$$ LANGUAGE 'plpgsql';
-
-CREATE OR REPLACE FUNCTION createpr(INTEGER, CHARACTER, INTEGER, TEXT) RETURNS INTEGER AS $$
--- Copyright (c) 1999-2019 by OpenMFG LLC, d/b/a xTuple. 
--- See www.xtuple.com/CPAL for the full text of the software license.
-DECLARE
-  pOrderNumber ALIAS FOR $1;
-  pParentType ALIAS FOR $2;
-  pParentId ALIAS FOR $3;
-  pParentNotes ALIAS FOR $4;
-  _parent RECORD;
-  _prid INTEGER;
-  _orderNumber INTEGER;
-
-BEGIN
-
-  IF (pOrderNumber = -1) THEN
-    SELECT fetchPrNumber() INTO _orderNumber;
-  ELSE
-    _orderNumber := pOrderNumber;
-  END IF;
-
-  IF (pParentType = 'W') THEN
-    SELECT womatl_itemsite_id AS itemsiteid,
-           itemuomtouom(itemsite_item_id, womatl_uom_id, NULL, womatl_qtyreq) AS qty,
-           womatl_duedate AS duedate, wo_prj_id AS prjid INTO _parent
-    FROM wo, womatl, itemsite
-    WHERE ((womatl_wo_id=wo_id)
-     AND (womatl_itemsite_id=itemsite_id)
-     AND (womatl_id=pParentId));
-
-  ELSIF (pParentType = 'S') THEN
-    SELECT coitem_itemsite_id AS itemsiteid,
-           (coitem_qtyord - coitem_qtyshipped + coitem_qtyreturned) AS qty,
-           coitem_scheddate AS duedate, cohead_prj_id AS prjid INTO _parent
-    FROM coitem, cohead
-    WHERE ((cohead_id=coitem_cohead_id)
-     AND (coitem_id=pParentId));
-
-  ELSIF (pParentType = 'F') THEN
-    SELECT planord_itemsite_id AS itemsiteid,
-           planord_qty AS qty,
-           planord_duedate AS duedate, NULL::INTEGER AS prjid 
-           INTO _parent
-    FROM planord
-    WHERE (planord_id=pParentId);
-
-  ELSE
-    RETURN -2;
-  END IF;
-
-  IF (NOT FOUND) THEN
-    RETURN -1;
-  END IF;
-
-  SELECT NEXTVAL('pr_pr_id_seq') INTO _prid;
-  INSERT INTO pr
-  ( pr_id, pr_number, pr_subnumber, pr_status,
-    pr_order_type, pr_order_id, pr_prj_id,
-    pr_itemsite_id, pr_qtyreq, pr_duedate, pr_releasenote )
-  VALUES
-  ( _prid, _orderNumber, nextPrSubnumber(_orderNumber), 'O',
-    pParentType, pParentId, _parent.prjid,
-    _parent.itemsiteid, validateOrderQty(_parent.itemsiteid, _parent.qty, TRUE),
-    _parent.duedate, pParentNotes );
+  _prid := createPr(
+    _orderNumber,
+    _parent.itemsiteid,
+    validateOrderQty(_parent.itemsiteid, _parent.qty, TRUE),
+    _parent.duedate,
+    COALESCE(pParentNotes, _parent.notes),
+    pParentType,
+    pParentId
+  );
 
   RETURN _prid;
 

--- a/foundation-database/public/functions/createpr.sql
+++ b/foundation-database/public/functions/createpr.sql
@@ -34,7 +34,7 @@ BEGIN
     pr_itemsite_id, pr_qtyreq, pr_duedate, pr_releasenote )
   VALUES
   ( _prid, pOrderNumber, nextPrSubnumber(pOrderNumber), 'O',
-    pOrderType, pOrderId, pProjId
+    pOrderType, pOrderId, pProjId,
     pItemsiteid, pQty, pDuedate, pNotes );
 
   RETURN _prid;


### PR DESCRIPTION
When a user does not have `OverrideTax` priv, the `coitem_taxtype_change` trigger causes a cascade of updates to coitem which ends up creating two PRs for one line on a order.

Similar to how `createpurchasetosale()` checks for an existing PO before creating one, make `createpr()` check for an existing PR before creating one. This prevents the duplication of PRs.

Also cleanup the `createpr()` functions to reduce the duplication and follow latest coding standards.
